### PR TITLE
desktop: fall back to Edge browser folder when WebView2 Runtime is missing

### DIFF
--- a/src/desktop/main.cpp
+++ b/src/desktop/main.cpp
@@ -35,6 +35,7 @@
 #include <nlohmann/json.hpp>
 
 #include <atomic>
+#include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <mutex>
@@ -316,6 +317,16 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
 #else
 int main(int, char**) {
 #endif
+    // 顶层 try/catch:wWinMain 是 Windows 子系统的 EXE 入口,任何未捕获的
+    // C++ 异常会触发 std::terminate → 系统弹"未经处理的异常"调试器对话框,
+    // 普通用户既看不懂也无从下手。把整个 body 包成 IIFE lambda 让 catch 兜
+    // 底:落 LOG_ERROR、弹中文 MessageBox 给用户可执行的修复指引,然后
+    // return 1 走正常退出。
+    //
+    // 注意 logger 初始化也在 lambda 内,因为它本身也可能抛(磁盘满 / 路径
+    // 受 GPO 锁)。catch 里依然先调 LOG_ERROR(失败时是 no-op,不影响
+    // MessageBox 给用户提示)。
+    auto run = []() -> int {
     using namespace acecode::desktop;
 
     // desktop 自己的日志路径: ~/.acecode/logs/desktop-<date>.log。和 daemon
@@ -1068,4 +1079,45 @@ int main(int, char**) {
 
     auto failures = pool.stop_all();
     return failures.empty() ? 0 : 100; // 部分失败返回非零便于诊断
+    }; // end of run lambda
+
+    try {
+        return run();
+    } catch (const std::exception& e) {
+        LOG_ERROR(std::string("[desktop] unhandled exception during startup: ") + e.what());
+#ifdef _WIN32
+        const std::string body = std::string(
+            "ACECode 桌面版启动时遇到未预期的错误,即将退出。\n\n"
+            "请把以下日志文件发给 IT/开发以便定位:\n"
+            "  %USERPROFILE%\\.acecode\\logs\\desktop-*.log\n\n"
+            "异常信息:\n") + e.what();
+        const int wlen = ::MultiByteToWideChar(CP_UTF8, 0, body.c_str(),
+                                               static_cast<int>(body.size()), nullptr, 0);
+        std::wstring wbody;
+        if (wlen > 0) {
+            wbody.resize(static_cast<std::size_t>(wlen));
+            ::MultiByteToWideChar(CP_UTF8, 0, body.c_str(),
+                                  static_cast<int>(body.size()), wbody.data(), wlen);
+        }
+        ::MessageBoxW(nullptr,
+                      wbody.empty() ? L"Unhandled exception during startup." : wbody.c_str(),
+                      L"ACECode 启动失败",
+                      MB_OK | MB_ICONERROR | MB_SETFOREGROUND);
+#else
+        std::fprintf(stderr, "[desktop] unhandled exception: %s\n", e.what());
+#endif
+        return 1;
+    } catch (...) {
+        LOG_ERROR("[desktop] unhandled non-std::exception during startup");
+#ifdef _WIN32
+        ::MessageBoxW(nullptr,
+                      L"ACECode 桌面版启动时遇到未预期的错误,即将退出。\n"
+                      L"请把日志文件 %USERPROFILE%\\.acecode\\logs\\desktop-*.log 发给 IT 团队。",
+                      L"ACECode 启动失败",
+                      MB_OK | MB_ICONERROR | MB_SETFOREGROUND);
+#else
+        std::fprintf(stderr, "[desktop] unhandled non-std::exception during startup\n");
+#endif
+        return 1;
+    }
 }

--- a/src/desktop/web_host.cpp
+++ b/src/desktop/web_host.cpp
@@ -1,6 +1,7 @@
 #include "web_host.hpp"
 
 #include "web_host_close_policy.hpp"
+#include "webview2_runtime_probe.hpp"
 #include "window_chrome.hpp"
 
 #include "../utils/logger.hpp"
@@ -296,6 +297,37 @@ void center_window_on_monitor(HWND hwnd, const RECT& monitor) {
     ::SetWindowPos(hwnd, nullptr, x, y, w, h, SWP_NOZORDER | SWP_NOACTIVATE);
 }
 
+// 终态失败弹窗:WebView2 默认路径 + Edge 浏览器 fallback 都失败时,给用户
+// 一个可读中文提示(原本是 wWinMain 上面那个"未经处理的异常"调试器对话框,
+// 普通用户看不懂也帮不上忙)。reason 透传 webview::exception::what(),通常
+// 含 HRESULT;接进 MessageBox 文案末尾,IT 排查时直接复制就行。
+void show_webview2_failure_message_box(const char* reason) {
+    const std::string body =
+        "ACECode 桌面版无法初始化 WebView2 组件。\n\n"
+        "可能的原因与解决办法:\n"
+        "  1. 未安装 \"Microsoft Edge WebView2 Runtime\"(注意:仅有 Edge 浏览器并不等价)。\n"
+        "     请到 https://developer.microsoft.com/microsoft-edge/webview2/ 下载 Evergreen Standalone Installer 安装。\n"
+        "  2. WebView2 用户数据目录损坏。请尝试删除以下目录后重试:\n"
+        "     %LOCALAPPDATA%\\acecode-desktop\\EBWebView\n"
+        "  3. 杀毒/EDR 软件拦截了 msedgewebview2.exe 的启动,请将其加入信任。\n\n"
+        "详细日志:%USERPROFILE%\\.acecode\\logs\\desktop-*.log\n\n"
+        "失败原因(供 IT 排查):\n";
+    std::string full = body + (reason ? reason : "(unknown)");
+
+    const int wlen = ::MultiByteToWideChar(CP_UTF8, 0, full.c_str(),
+                                           static_cast<int>(full.size()), nullptr, 0);
+    std::wstring wbody;
+    if (wlen > 0) {
+        wbody.resize(static_cast<std::size_t>(wlen));
+        ::MultiByteToWideChar(CP_UTF8, 0, full.c_str(),
+                              static_cast<int>(full.size()), wbody.data(), wlen);
+    }
+    ::MessageBoxW(nullptr,
+                  wbody.empty() ? L"WebView2 initialization failed." : wbody.c_str(),
+                  L"ACECode 启动失败",
+                  MB_OK | MB_ICONERROR | MB_SETFOREGROUND);
+}
+
 } // namespace
 
 struct ComApartment {
@@ -348,20 +380,65 @@ struct WebHost::Impl {
                             : nullptr),
           offscreen_until_ready(custom_window != nullptr),
           com(custom_window != nullptr) {
-        try {
-            w = std::make_unique<webview::webview>(
-                debug,
-                custom_window ? static_cast<void*>(custom_window) : nullptr);
-        } catch (const webview::exception& e) {
-            if (!custom_window) throw;
-            LOG_WARN(std::string("[desktop] offscreen WebView host failed; falling back: ") +
-                     e.what());
-            if (::IsWindow(custom_window)) {
-                ::DestroyWindow(custom_window);
+        // 三段式构造:
+        //   (1) 默认 Loader 路径,优先 offscreen custom_window;失败 → 切
+        //       自管 nullptr 父窗口再试一次(沿用现有降级)。
+        //   (2) (1) 整段还是抛 → 探测 Edge 浏览器自带的 msedgewebview2.exe
+        //       目录,通过 WEBVIEW2_BROWSER_EXECUTABLE_FOLDER 环境变量
+        //       (WebView2Loader.dll 公开的覆盖钩子)指过去再试。
+        //   (3) Edge fallback 仍失败或没找到 Edge → 弹中文 MessageBox 给用户
+        //       可执行的修复指引,LOG_ERROR 落盘后 ExitProcess(1) 而不是
+        //       让 webview::exception 一路裸抛到 wWinMain — 那样普通用户
+        //       只会看到 Windows "未经处理的异常" 调试器对话框,完全看不懂。
+        auto make_webview_default_path = [&]() -> std::unique_ptr<webview::webview> {
+            try {
+                return std::make_unique<webview::webview>(
+                    debug,
+                    custom_window ? static_cast<void*>(custom_window) : nullptr);
+            } catch (const webview::exception& e) {
+                if (!custom_window) throw;
+                LOG_WARN(std::string("[desktop] offscreen WebView host failed; "
+                                     "falling back to default window: ") + e.what());
+                if (::IsWindow(custom_window)) {
+                    ::DestroyWindow(custom_window);
+                }
+                custom_window = nullptr;
+                offscreen_until_ready = false;
+                return std::make_unique<webview::webview>(debug, nullptr);
             }
-            custom_window = nullptr;
-            offscreen_until_ready = false;
-            w = std::make_unique<webview::webview>(debug, nullptr);
+        };
+
+        try {
+            w = make_webview_default_path();
+        } catch (const webview::exception& e1) {
+            LOG_WARN(std::string("[desktop] WebView2 default loader path failed: ") +
+                     e1.what());
+            auto edge_folder = find_edge_browser_folder();
+            if (!edge_folder.has_value()) {
+                LOG_ERROR("[desktop] no Microsoft Edge browser folder found to "
+                          "fall back to; aborting startup");
+                show_webview2_failure_message_box(e1.what());
+                ::ExitProcess(1);
+            }
+            const std::wstring folder_w = edge_folder->wstring();
+            LOG_INFO(std::string("[desktop] retrying WebView2 with Edge browser "
+                                 "folder: ") + edge_folder->string());
+            if (!::SetEnvironmentVariableW(L"WEBVIEW2_BROWSER_EXECUTABLE_FOLDER",
+                                           folder_w.c_str())) {
+                LOG_ERROR("[desktop] SetEnvironmentVariableW("
+                          "WEBVIEW2_BROWSER_EXECUTABLE_FOLDER) failed, last_error=" +
+                          std::to_string(::GetLastError()));
+            }
+            try {
+                // custom_window 在 default 路径内已被清掉(如果走过 offscreen),
+                // 这里直接喂 nullptr 让 webview 自己造窗口最稳妥。
+                w = std::make_unique<webview::webview>(debug, nullptr);
+            } catch (const webview::exception& e2) {
+                LOG_ERROR(std::string("[desktop] WebView2 Edge browser folder "
+                                      "fallback also failed: ") + e2.what());
+                show_webview2_failure_message_box(e2.what());
+                ::ExitProcess(1);
+            }
         }
         if (custom_window) {
             resize_webview_widget(custom_window);

--- a/src/desktop/webview2_runtime_probe.cpp
+++ b/src/desktop/webview2_runtime_probe.cpp
@@ -1,0 +1,174 @@
+// WebView2 Runtime 探测实现。设计 + 调用时机见 webview2_runtime_probe.hpp。
+
+#include "webview2_runtime_probe.hpp"
+
+#include "../utils/logger.hpp"
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <system_error>
+
+#ifdef _WIN32
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#  endif
+#  include <windows.h>
+#  include <shlobj.h>
+#  include <knownfolders.h>
+#endif
+
+namespace fs = std::filesystem;
+
+namespace acecode::desktop {
+
+namespace {
+
+constexpr const char* kEdgeWebViewExecutableName = "msedgewebview2.exe";
+
+// 把版本号字符串("100.0.1234.56")拆 4 段非负整数。失败返回 std::nullopt
+// (整段不是 4 位、含非数字字符、任何一段超过 uint32 上限都视为非版本)。
+std::optional<std::array<std::uint32_t, 4>> parse_version_4(const std::string& s) {
+    std::array<std::uint32_t, 4> out{0, 0, 0, 0};
+    std::size_t segment = 0;
+    std::uint64_t acc = 0;
+    bool any_digit_in_segment = false;
+    for (std::size_t i = 0; i <= s.size(); ++i) {
+        const bool at_end = (i == s.size());
+        const char c = at_end ? '.' : s[i];
+        if (c == '.') {
+            if (!any_digit_in_segment) return std::nullopt;
+            if (segment >= 4) return std::nullopt;
+            if (acc > 0xFFFFFFFFu) return std::nullopt;
+            out[segment] = static_cast<std::uint32_t>(acc);
+            ++segment;
+            acc = 0;
+            any_digit_in_segment = false;
+            continue;
+        }
+        if (c < '0' || c > '9') return std::nullopt;
+        acc = acc * 10 + static_cast<std::uint64_t>(c - '0');
+        if (acc > 0xFFFFFFFFu) return std::nullopt;
+        any_digit_in_segment = true;
+    }
+    if (segment != 4) return std::nullopt;
+    return out;
+}
+
+// Edge 浏览器标准布局 <root>/Microsoft/Edge/Application/。我们只用这一条
+// 路径 — Edge Beta/Dev/Canary 各有自己的 root,但同事场景下用户装的就是
+// 正式版 Edge,本期不扫 Beta/Dev/Canary,避免误用 Canary 这种快速变化通道。
+fs::path edge_application_dir(const fs::path& root) {
+    return root / "Microsoft" / "Edge" / "Application";
+}
+
+// 在一个 Application 目录下扫所有合法版本子目录,挑最大版本 + 验证
+// msedgewebview2.exe 存在。返回 (version, folder),无候选返回 nullopt。
+std::optional<std::pair<std::array<std::uint32_t, 4>, fs::path>>
+pick_latest_in_application_dir(const fs::path& application_dir) {
+    std::error_code ec;
+    if (!fs::is_directory(application_dir, ec) || ec) {
+        return std::nullopt;
+    }
+
+    std::optional<std::array<std::uint32_t, 4>> best_version;
+    fs::path best_folder;
+
+    fs::directory_iterator it(application_dir, fs::directory_options::skip_permission_denied, ec);
+    if (ec) return std::nullopt;
+
+    for (const auto& entry : it) {
+        std::error_code ec_entry;
+        if (!entry.is_directory(ec_entry) || ec_entry) continue;
+
+        const std::string name = entry.path().filename().string();
+        auto parsed = parse_version_4(name);
+        if (!parsed.has_value()) continue;
+
+        const fs::path candidate_exe = entry.path() / kEdgeWebViewExecutableName;
+        std::error_code exe_ec;
+        if (!fs::is_regular_file(candidate_exe, exe_ec) || exe_ec) {
+            // Edge 浏览器某些 channel 切换时会保留只剩 Resources 的旧版本号
+            // 目录,但没了 msedgewebview2.exe — 直接跳过,免得后面 set env
+            // 指向死路径。
+            continue;
+        }
+
+        if (!best_version.has_value() || *parsed > *best_version) {
+            best_version = parsed;
+            best_folder = entry.path();
+        }
+    }
+
+    if (!best_version.has_value()) return std::nullopt;
+    return std::make_pair(*best_version, best_folder);
+}
+
+} // namespace
+
+std::optional<fs::path> find_edge_browser_folder_in(
+    const std::vector<fs::path>& roots) {
+    std::optional<std::array<std::uint32_t, 4>> best_version;
+    fs::path best_folder;
+
+    for (const auto& root : roots) {
+        if (root.empty()) continue;
+        auto pick = pick_latest_in_application_dir(edge_application_dir(root));
+        if (!pick.has_value()) continue;
+
+        if (!best_version.has_value() || pick->first > *best_version) {
+            best_version = pick->first;
+            best_folder = pick->second;
+        }
+    }
+
+    if (!best_version.has_value()) return std::nullopt;
+    return best_folder;
+}
+
+#ifdef _WIN32
+namespace {
+
+// SHGetKnownFolderPath 拿 KNOWNFOLDERID 对应路径。失败返回空 path。COM
+// 不需要 init —— SHGetKnownFolderPath 走的是 NTDLL 路径不依赖 apartment。
+fs::path known_folder_path(REFKNOWNFOLDERID id) {
+    PWSTR raw = nullptr;
+    HRESULT hr = ::SHGetKnownFolderPath(id, KF_FLAG_DEFAULT, nullptr, &raw);
+    if (FAILED(hr) || !raw) {
+        if (raw) ::CoTaskMemFree(raw);
+        return {};
+    }
+    fs::path result(raw);
+    ::CoTaskMemFree(raw);
+    return result;
+}
+
+} // namespace
+
+std::optional<fs::path> find_edge_browser_folder() {
+    std::vector<fs::path> roots;
+    if (auto pf = known_folder_path(FOLDERID_ProgramFiles); !pf.empty()) {
+        roots.push_back(std::move(pf));
+    }
+    if (auto pfx86 = known_folder_path(FOLDERID_ProgramFilesX86); !pfx86.empty()) {
+        roots.push_back(std::move(pfx86));
+    }
+    if (roots.empty()) {
+        LOG_WARN("[webview2_probe] SHGetKnownFolderPath returned no ProgramFiles paths");
+        return std::nullopt;
+    }
+    return find_edge_browser_folder_in(roots);
+}
+
+#else // _WIN32
+
+std::optional<fs::path> find_edge_browser_folder() {
+    return std::nullopt;
+}
+
+#endif // _WIN32
+
+} // namespace acecode::desktop

--- a/src/desktop/webview2_runtime_probe.hpp
+++ b/src/desktop/webview2_runtime_probe.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+// WebView2 Runtime 探测 — 给 acecode-desktop 在系统未安装独立 WebView2
+// Evergreen Runtime 时找一条 fallback。
+//
+// 背景:许多企业 / 信创环境的机器只装了 Microsoft Edge 浏览器,而没有单独
+// 安装 "Microsoft Edge WebView2 Runtime"。第三方 WebView2 应用(包括
+// acecode-desktop)默认走 WebView2Loader.dll 的 Evergreen Runtime 发现
+// 路径,这条路径不会去看 Edge 浏览器目录,导致 CreateCoreWebView2-
+// EnvironmentWithOptions 失败。绝大多数 Edge 100+ 版本的浏览器目录里也
+// 自带 msedgewebview2.exe + 同版本 dll,可以直接通过把
+// WEBVIEW2_BROWSER_EXECUTABLE_FOLDER 环境变量指过去复用,等价于
+// CreateCoreWebView2EnvironmentWithOptions 的 browserExecutableFolder
+// 参数(WebView2Loader.dll 加载时会优先读这个 env)。
+//
+// 调用时机:WebHost 第一次构造 webview::webview 失败时(catch 里),不要
+// 在启动早期主动 set,以免覆盖正常装了 Evergreen Runtime 的用户路径。
+//
+// 平台:Windows-only;POSIX 上头文件保持可见,但实现返回空(macOS / Linux
+// 走 WKWebView / WebKitGTK,跟 WebView2 无关)。
+
+#include <filesystem>
+#include <optional>
+#include <vector>
+
+namespace acecode::desktop {
+
+// 在给定的根目录列表中查找最新版本的 Edge 浏览器自带 msedgewebview2.exe
+// 所在文件夹。纯函数,不调系统 API,unit test 喂临时目录覆盖。
+//
+// 期望的目录结构(Edge 浏览器标准布局):
+//   <root>/Microsoft/Edge/Application/<version>/msedgewebview2.exe
+// version 必须是 4 段数字格式 "<n>.<n>.<n>.<n>"(过滤 "SetupMetrics" /
+// "Installer" / 回滚备份目录等非版本 entry)。
+//
+// 返回:命中时 = 包含 msedgewebview2.exe 的那个 <version> 目录绝对路径。
+//      未命中 = std::nullopt。
+//
+// 排序:存在多个版本子目录时,按 4 段版本号数值字典序选最大版本。
+// 多个 root 都命中时,**返回所有命中里版本号最大的那个**(不是按 root 顺序),
+// 这样 PF 与 PFx86 都装了 Edge 的机器拿到最新一份。
+std::optional<std::filesystem::path> find_edge_browser_folder_in(
+    const std::vector<std::filesystem::path>& roots);
+
+// Windows 系统调用版:用 SHGetKnownFolderPath 拿 ProgramFiles 与
+// ProgramFiles(x86) 两个根,调上面的纯函数。POSIX 上始终返回 std::nullopt。
+//
+// 失败语义和 find_edge_browser_folder_in 一致:返回 nullopt 表示当前机器
+// 没有可复用的 Edge 浏览器二进制,调用方应当向用户提示安装 WebView2 Runtime。
+std::optional<std::filesystem::path> find_edge_browser_folder();
+
+} // namespace acecode::desktop

--- a/tests/desktop/webview2_runtime_probe_test.cpp
+++ b/tests/desktop/webview2_runtime_probe_test.cpp
@@ -1,0 +1,168 @@
+// 覆盖 src/desktop/webview2_runtime_probe.cpp 中的纯函数 find_edge_browser_folder_in。
+// 系统调用版 find_edge_browser_folder() 不在测试范围 — 它依赖 SHGetKnownFolderPath,
+// 在 unit test 进程里直接喂临时目录列表更直观。
+
+#include <gtest/gtest.h>
+
+#include "desktop/webview2_runtime_probe.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace fs = std::filesystem;
+using acecode::desktop::find_edge_browser_folder_in;
+
+namespace {
+
+// 单测用临时根目录,析构时清理。各 case 独立目录,避免并发污染。
+class TempDir {
+public:
+    TempDir() {
+        std::random_device rd;
+        std::mt19937 rng(rd());
+        std::uniform_int_distribution<int> dist(0, 0x7FFFFFFF);
+        for (int attempt = 0; attempt < 8; ++attempt) {
+            const std::string name = "acecode_webview2_probe_" +
+                                     std::to_string(dist(rng));
+            fs::path candidate = fs::temp_directory_path() / name;
+            std::error_code ec;
+            if (fs::create_directories(candidate, ec) && !ec) {
+                path_ = candidate;
+                return;
+            }
+        }
+        ADD_FAILURE() << "could not create unique temp dir";
+    }
+
+    ~TempDir() {
+        std::error_code ec;
+        fs::remove_all(path_, ec);
+    }
+
+    TempDir(const TempDir&) = delete;
+    TempDir& operator=(const TempDir&) = delete;
+
+    const fs::path& path() const { return path_; }
+
+private:
+    fs::path path_;
+};
+
+// 在 root 下造一个 Edge 浏览器风格的版本子目录,可选地写一个 placeholder
+// msedgewebview2.exe(传 false 时只造目录、不造文件 — 用于覆盖
+// "目录在但 exe 缺失" 的过滤分支)。
+fs::path make_version_folder(const fs::path& root,
+                             const std::string& version,
+                             bool with_exe = true) {
+    fs::path application = root / "Microsoft" / "Edge" / "Application";
+    fs::path folder = application / version;
+    std::error_code ec;
+    fs::create_directories(folder, ec);
+    EXPECT_FALSE(ec) << ec.message();
+    if (with_exe) {
+        std::ofstream(folder / "msedgewebview2.exe") << "stub";
+    }
+    return folder;
+}
+
+} // namespace
+
+// 完全空的根目录列表 → nullopt
+TEST(Webview2RuntimeProbe, EmptyRootsReturnsNullopt) {
+    EXPECT_FALSE(find_edge_browser_folder_in({}).has_value());
+}
+
+// 根目录存在但里面没有 Edge\Application → nullopt
+TEST(Webview2RuntimeProbe, RootWithoutEdgeReturnsNullopt) {
+    TempDir d;
+    auto result = find_edge_browser_folder_in({d.path()});
+    EXPECT_FALSE(result.has_value());
+}
+
+// 单一版本子目录 + msedgewebview2.exe → 命中并返回该目录
+TEST(Webview2RuntimeProbe, SingleVersionWithExeIsPicked) {
+    TempDir d;
+    fs::path expected = make_version_folder(d.path(), "120.0.2210.91");
+    auto result = find_edge_browser_folder_in({d.path()});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->lexically_normal(), expected.lexically_normal());
+}
+
+// 多个合法版本 → 选 4 段版本号最大的
+TEST(Webview2RuntimeProbe, PicksLatestVersionByNumericCompare) {
+    TempDir d;
+    make_version_folder(d.path(), "100.0.1185.39");
+    make_version_folder(d.path(), "120.0.2210.91");
+    fs::path latest = make_version_folder(d.path(), "131.0.2903.86");
+    make_version_folder(d.path(), "129.0.2792.79");
+
+    auto result = find_edge_browser_folder_in({d.path()});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->lexically_normal(), latest.lexically_normal());
+}
+
+// 字典序陷阱:"99.0.1.1" 字符串字典序 > "100.0.1.1",但数值 99 < 100,
+// 实现必须按数值比较。
+TEST(Webview2RuntimeProbe, NumericNotLexicographicVersionOrder) {
+    TempDir d;
+    make_version_folder(d.path(), "99.0.1.1");
+    fs::path latest = make_version_folder(d.path(), "100.0.1.1");
+
+    auto result = find_edge_browser_folder_in({d.path()});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->lexically_normal(), latest.lexically_normal());
+}
+
+// 非 4 段版本号格式的目录(SetupMetrics、Installer、3 段、空段、字母)被忽略
+TEST(Webview2RuntimeProbe, FiltersNonVersionFolders) {
+    TempDir d;
+    make_version_folder(d.path(), "SetupMetrics");
+    make_version_folder(d.path(), "Installer");
+    make_version_folder(d.path(), "100.0.1234"); // 只 3 段
+    make_version_folder(d.path(), "100..0.1.1"); // 含空段
+    make_version_folder(d.path(), "100.0.1.1a"); // 含字母
+    fs::path good = make_version_folder(d.path(), "120.0.2210.91");
+
+    auto result = find_edge_browser_folder_in({d.path()});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->lexically_normal(), good.lexically_normal());
+}
+
+// 版本目录在但 msedgewebview2.exe 缺失(Edge channel 切换残留场景)→ 跳过。
+// 否则会把死路径喂给 SetEnvironmentVariableW,WebView2 加载时再炸一次。
+TEST(Webview2RuntimeProbe, SkipsVersionFolderWithoutExecutable) {
+    TempDir d;
+    make_version_folder(d.path(), "131.0.2903.86", /*with_exe=*/false);
+    fs::path with_exe = make_version_folder(d.path(), "120.0.2210.91");
+
+    auto result = find_edge_browser_folder_in({d.path()});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->lexically_normal(), with_exe.lexically_normal());
+}
+
+// 多个 root 都装了 Edge:返回所有 root 命中里版本号最大的(模拟 PF 与 PFx86
+// 都装了 Edge 的机器,选最新一份)。
+TEST(Webview2RuntimeProbe, AcrossMultipleRootsPicksGlobalLatest) {
+    TempDir pf;
+    TempDir pfx86;
+    make_version_folder(pf.path(), "120.0.2210.91");
+    fs::path latest = make_version_folder(pfx86.path(), "131.0.2903.86");
+
+    auto result = find_edge_browser_folder_in({pf.path(), pfx86.path()});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->lexically_normal(), latest.lexically_normal());
+}
+
+// 空字符串 root 元素被静默跳过(防御性 — SHGetKnownFolderPath 失败时
+// production 代码会插入空 path)。
+TEST(Webview2RuntimeProbe, EmptyRootEntryIgnored) {
+    TempDir d;
+    fs::path good = make_version_folder(d.path(), "120.0.2210.91");
+    auto result = find_edge_browser_folder_in({fs::path(), d.path()});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->lexically_normal(), good.lexically_normal());
+}


### PR DESCRIPTION
## 背景

很多企业 / 信创环境的机器只装了 Microsoft Edge 浏览器,而**没有单独安装 "Microsoft Edge WebView2 Runtime"**(独立 Evergreen Runtime,注册路径 `HKLM\...\EdgeUpdate\Clients\{F3017226-...}`)。这种状态下:

1. acecode-desktop 调 `webview::webview` ctor → 内部 `CreateCoreWebView2EnvironmentWithOptions` 找不到 Runtime → 抛 `webview::exception`
2. `WebHost::Impl` 仅对"offscreen → nullptr"做了一层 fallback,nullptr 路径再失败时直接裸抛
3. `wWinMain` 没有顶层 try/catch → `std::terminate` → Windows 弹"未经处理的异常"调试器对话框

普通用户既看不懂也无从下手。同事 / IT 反馈"已经装了 webview2 / Edge 也没用"时,这就是根因。

## 方案

`WebView2Loader` 公开了 `WEBVIEW2_BROWSER_EXECUTABLE_FOLDER` 环境变量(等价于 `CreateCoreWebView2EnvironmentWithOptions` 的 `browserExecutableFolder` 参数),而 Edge 100+ 浏览器目录里都自带同版本的 `msedgewebview2.exe` + 配套 dll,可以直接复用 —— **零打包代价**(对比 Fixed Version Runtime 要 +180MB)。

策略:**正常路径优先,失败再 fallback Edge 目录**,对装了 Evergreen Runtime 的正常用户零行为变化。

## 改动

### 新增

- **`src/desktop/webview2_runtime_probe.{hpp,cpp}`** — Edge 浏览器目录探测器
  - `find_edge_browser_folder_in(roots)`:纯函数,接受根目录列表 → 扫 `<root>/Microsoft/Edge/Application/<4 段版本号>/msedgewebview2.exe` → 返回最新版本所在目录(按数值比较,跨 root 全局最大)
  - `find_edge_browser_folder()`:Win32 系统调用版,用 `SHGetKnownFolderPath` 拿 ProgramFiles + ProgramFiles(x86) 调上面纯函数;POSIX 上 stub 返回 `nullopt`
  - 过滤 `SetupMetrics` / `Installer` / 非 4 段版本号目录;跳过版本目录在但 `msedgewebview2.exe` 缺失的情况(Edge channel 切换残留)

- **`tests/desktop/webview2_runtime_probe_test.cpp`** — 8 个 GoogleTest 用例,覆盖纯函数:
  - 空 roots / 根目录无 Edge → `nullopt`
  - 单版本 + 多版本数值排序(字典序陷阱:`"99.0.1.1"` vs `"100.0.1.1"`)
  - 非版本目录过滤
  - 缺 exe 跳过
  - 跨多 root 全局最新

### 修改

- **`src/desktop/web_host.cpp::WebHost::Impl::Impl`** — 三段式构造:
  1. 默认 Loader 路径(优先 offscreen custom_window,失败切 nullptr 重试 — 沿用原降级)
  2. (1) 整段还抛 → 调 `find_edge_browser_folder()` → `SetEnvironmentVariableW(WEBVIEW2_BROWSER_EXECUTABLE_FOLDER)` → 重试构造
  3. Edge fallback 仍失败 / 没找到 Edge → `show_webview2_failure_message_box` 弹中文 MessageBox 给用户可执行的修复指引(装 Runtime / 删 EBWebView / 杀软白名单),`LOG_ERROR` 落盘后 `ExitProcess(1)`

- **`src/desktop/main.cpp::wWinMain`** — IIFE lambda 包整个 body + 顶层 `try / catch (std::exception&) / catch (...)`,兜底任何其他启动期未捕获异常,落 `LOG_ERROR` + 中文 MessageBox + `return 1`,避免再有"无声秒退"。

## CMake 集成

零变更:
- `src/desktop/webview2_runtime_probe.cpp` 不在 `ACECODE_DESKTOP_BINARY_ONLY_SOURCES` 列表 → 自动进 `acecode_testable` → `acecode-desktop` 通过 `target_link_libraries(acecode-desktop PRIVATE acecode_testable)` 拿到
- `acecode_testable` 在 Win32 已 link `shell32`(folder_picker 用),`SHGetKnownFolderPath` 不需要额外 link
- `tests/desktop/webview2_runtime_probe_test.cpp` 由 `tests/CMakeLists.txt` 的 `GLOB_RECURSE *_test.cpp` 自动拾取

## 验证

- POSIX 路径下 `webview2_runtime_probe.cpp` `g++ -std=c++17` 编译通过
- 用合成临时目录树(SetupMetrics + 100.0.x + 131.0.x + 缺 exe 的 99.0.x)运行 probe 函数,行为符合预期(选 131,跳过 SetupMetrics 和缺 exe 的目录)
- Linux 环境无 vcpkg + 无 Windows SDK,**完整 acecode-desktop 构建需要在 Windows 验证**;Win32 路径主要风险点已审:括号匹配 / `MessageBoxW` 调用 / `SetEnvironmentVariableW` UTF-16 / lambda capture

## Test plan

- [ ] Windows 构建 `acecode-desktop` 正常通过(`-DACECODE_BUILD_DESKTOP=ON`)
- [ ] `acecode_unit_tests` 跑 `Webview2RuntimeProbe.*` 全绿
- [ ] 在装了 Evergreen Runtime 的正常机器上启动 acecode-desktop,日志确认未走 fallback 分支
- [ ] 在只装 Edge 没装 Runtime 的机器上启动 acecode-desktop,日志看到 `[desktop] retrying WebView2 with Edge browser folder: ...`,窗口正常起来
- [ ] 在没有 Edge 也没有 Runtime 的机器上启动,弹中文 MessageBox 给修复指引,而不是 Windows 调试器对话框


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfP3TMCeNao3A52G9JuP4q)_