### PR TITLE
fix(web): 变更视图三处交互优化(删冗余标题行 / 转到文件按钮 / 折叠全部 diff)

### DIFF
--- a/web/src/components/ChatView.jsx
+++ b/web/src/components/ChatView.jsx
@@ -3087,6 +3087,7 @@ export function ChatView({ sessionRef, sessionId, onSessionPromoted, onCommandWo
             onToggleMaximize={onToggleSidePanelMaximized}
             onSelectChangeFile={openSessionChangePreview}
             onSelectGitChangeFile={openGitChangePreview}
+            onOpenFilePreview={openFilePreview}
           />
         </div>
       )}

--- a/web/src/components/GitChangeReview.jsx
+++ b/web/src/components/GitChangeReview.jsx
@@ -58,7 +58,7 @@ function statusBadgeClass(status) {
   }
 }
 
-function GitChangeFileRow({ row, open, selected, onToggle }) {
+function GitChangeFileRow({ row, open, selected, onToggle, onOpenFile }) {
   const name = row.path.split(/[\\/]/).pop();
   const parent = row.path.includes('/') ? row.path.slice(0, row.path.lastIndexOf('/')) : '';
   return (
@@ -89,6 +89,25 @@ function GitChangeFileRow({ row, open, selected, onToggle }) {
           <span className="text-fg-mute">{row.statLabel}</span>
         )}
       </span>
+      {!!onOpenFile && (
+        // 已删除文件磁盘上不存在,按钮隐形占位保持各行 ± 计数对齐。
+        <span
+          role="button"
+          tabIndex={-1}
+          className={clsx('ace-change-row-action', row.status === 'D' && 'is-hidden')}
+          title="转到文件"
+          aria-label={`转到文件 ${row.path}`}
+          onPointerDown={(event) => event.stopPropagation()}
+          onMouseDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            if (row.status !== 'D') onOpenFile(row.path);
+          }}
+        >
+          <VsIcon name="openFile" size={13} />
+        </span>
+      )}
     </button>
   );
 }
@@ -101,6 +120,7 @@ export function GitChangeDetails({
   expandedFileRevision = 0,
   busy = false,
   onSelectFile,
+  onOpenFilePreview,
 }) {
   const [list, setList] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -315,41 +335,30 @@ export function GitChangeDetails({
 
   return (
     <div className="ace-review-panel" data-change-region="preview-panel" ref={panelRef}>
-      <div className="ace-review-summary" data-desktop-review-kind="summary">
-        <div className="ace-review-title min-w-0">
-          <VsIcon name="editWindow" size={15} />
-          <span>变更</span>
-          {(list?.branch) && (
-            <>
-              <span className="text-fg-mute font-normal truncate max-w-[120px]" title={list.branch}>{list.branch}</span>
-              <span className="text-fg-mute opacity-60" aria-hidden="true">→</span>
-            </>
-          )}
-          <span className="text-fg-mute font-normal truncate max-w-[140px]" title={`比较基线:${base}`}>{base}</span>
-        </div>
-        <div className="flex items-center gap-2 shrink-0">
-          {loading && <span className="ace-spinner w-3 h-3" />}
-          {list && (
-            <span className="text-[11px]">
-              <span className="ace-change-add">+{list.total_additions ?? 0}</span>{' '}
-              <span className="ace-change-del">-{list.total_deletions ?? 0}</span>
-            </span>
-          )}
-          <button
-            type="button"
-            className="ace-side-panel-refresh-btn !static"
-            title="刷新变更"
-            aria-label="刷新变更"
-            onClick={() => { changesCache.markStale(cwdRef.current); setPatches({}); fetchList(true); }}
-          >
-            <VsIcon name="refresh" size={14} />
-          </button>
-        </div>
-      </div>
-
-      {list && rows.length > 0 && (
-        <div className="px-3 py-1 text-[11px] text-fg-mute border-b border-border/50 truncate">
-          {buildSummaryLabel(list)}
+      {(list || loading) && (
+        <div
+          className="px-3 py-1 text-[11px] text-fg-mute border-b border-border/50 flex items-center gap-2 shrink-0"
+          data-desktop-review-kind="summary"
+        >
+          <span className="truncate">{buildSummaryLabel(list)}</span>
+          {loading && <span className="ace-spinner w-3 h-3 shrink-0" />}
+          <span className="ml-auto shrink-0 inline-flex items-center gap-1.5">
+            {list && (
+              <span>
+                <span className="ace-change-add">+{list.total_additions ?? 0}</span>{' '}
+                <span className="ace-change-del">-{list.total_deletions ?? 0}</span>
+              </span>
+            )}
+            <button
+              type="button"
+              className="ace-review-collapse-all-btn"
+              title="折叠全部 diff"
+              aria-label="折叠全部 diff"
+              onClick={() => setOpenFiles(new Set())}
+            >
+              <VsIcon name="collapseAll" size={14} />
+            </button>
+          </span>
         </div>
       )}
 
@@ -387,6 +396,7 @@ export function GitChangeDetails({
                 open={open}
                 selected={selected}
                 onToggle={() => toggleFile(row.path, open)}
+                onOpenFile={onOpenFilePreview}
               />
               {open && (
                 <div className="ace-review-diff-scroll">

--- a/web/src/components/GitChangesPanel.jsx
+++ b/web/src/components/GitChangesPanel.jsx
@@ -40,6 +40,7 @@ export function GitChangesPanel({
   visible = true,
   selectedFile = '',
   onOpenFile,
+  onOpenFilePreview,
   onBaseChange,
 }) {
   const { candidates, initial } = useMemo(
@@ -260,6 +261,25 @@ export function GitChangesPanel({
                 )
                 : <span className="text-fg-mute">{row.statLabel}</span>}
             </span>
+            {!!onOpenFilePreview && (
+              // 已删除文件磁盘上不存在,按钮隐形占位保持各行 ± 计数对齐。
+              <span
+                role="button"
+                tabIndex={-1}
+                className={clsx('ace-change-row-action', row.status === 'D' && 'is-hidden')}
+                title="转到文件"
+                aria-label={`转到文件 ${row.path}`}
+                onPointerDown={(event) => event.stopPropagation()}
+                onMouseDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  if (row.status !== 'D') onOpenFilePreview(row.path);
+                }}
+              >
+                <VsIcon name="openFile" size={13} />
+              </span>
+            )}
           </button>
         ))}
       </div>

--- a/web/src/components/PreviewDetailsPanel.jsx
+++ b/web/src/components/PreviewDetailsPanel.jsx
@@ -185,6 +185,7 @@ export function PreviewDetailsPanel({
   onToggleMaximize,
   onSelectChangeFile,
   onSelectGitChangeFile,
+  onOpenFilePreview,
 }) {
   const tabListRef = useRef(null);
   const tabDragRef = useRef(null);
@@ -250,6 +251,7 @@ export function PreviewDetailsPanel({
           expandedFileRevision={active.expandedFileRevision || 0}
           busy={busy}
           onSelectFile={onSelectGitChangeFile}
+          onOpenFilePreview={onOpenFilePreview}
         />
       );
     }
@@ -263,7 +265,7 @@ export function PreviewDetailsPanel({
         onToggleWrapPreview={() => setWrapPreview((prev) => !prev)}
       />
     );
-  }, [active, api, busy, changeGroups, changeSummary, cwd, onSelectChangeFile, onSelectGitChangeFile, setWrapPreview, wrapPreview]);
+  }, [active, api, busy, changeGroups, changeSummary, cwd, onOpenFilePreview, onSelectChangeFile, onSelectGitChangeFile, setWrapPreview, wrapPreview]);
 
   const handleTabWheel = useCallback((event) => {
     const el = tabListRef.current;

--- a/web/src/components/SidePanel.jsx
+++ b/web/src/components/SidePanel.jsx
@@ -630,6 +630,7 @@ export function SidePanel({
             visible={!collapsed && activeTab === 'changes'}
             selectedFile={selectedGitChangeFile}
             onOpenFile={onOpenGitChangePreview}
+            onOpenFilePreview={onOpenFilePreview}
             onBaseChange={onGitBaseChange}
           />
         ) : (

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -2273,6 +2273,8 @@ body {
   min-height: 28px;
   display: grid;
   grid-template-columns: 18px minmax(0, 1fr) auto;
+  grid-auto-columns: max-content;
+  grid-auto-flow: column;
   align-items: center;
   gap: 5px;
   padding: 3px 8px;
@@ -2321,6 +2323,60 @@ body {
   font-family: var(--font-mono);
   font-size: 11px;
   white-space: nowrap;
+}
+
+/* 变更文件行的行内动作按钮(转到文件):hover / 选中 / 键盘聚焦时浮现,
+   平时透明占位保持 ± 计数各行对齐;is-hidden = 已删除文件的隐形占位。 */
+.ace-change-row-action {
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: 4px;
+  color: var(--ace-fg-mute);
+  opacity: 0;
+  transition: opacity .12s ease, color .15s ease, background .15s ease;
+}
+.ace-change-compact-row:hover .ace-change-row-action,
+.ace-change-compact-row.is-selected .ace-change-row-action,
+.ace-change-file-row:hover .ace-change-row-action,
+.ace-change-file-row.is-selected .ace-change-row-action,
+.ace-change-row-action:focus-visible {
+  opacity: 1;
+}
+.ace-change-row-action:hover {
+  color: var(--ace-fg);
+  background: var(--ace-surface-alt);
+}
+.ace-change-row-action.is-hidden {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+/* 变更详情栏「N 个文件已更改」行右端的折叠全部 diff 按钮。 */
+.ace-review-collapse-all-btn {
+  width: 24px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--ace-fg-mute);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color .15s ease, background .15s ease;
+}
+.ace-review-collapse-all-btn:hover {
+  color: var(--ace-fg);
+  background: var(--ace-surface-alt);
+}
+.ace-review-collapse-all-btn:focus-visible {
+  outline: 2px solid var(--ace-accent);
+  outline-offset: -2px;
 }
 
 .ace-review-panel {


### PR DESCRIPTION
## 改动内容

Web UI 变更(diff)视图的三处交互修复:

1. **删除详情栏顶部冗余标题行** — 中间详情栏「变更」页签原有的「变更 branch → origin/master +A -D ↻」整行移除(分支与基线信息在右侧 SidePanel 头部已有,纯重复)。`+A -D` 汇总与加载 spinner 并入「N 个文件已更改」行;右键菜单锚点 `data-desktop-review-kind="summary"` 迁移到新行,「展开/折叠/复制全部 diff」右键菜单行为不变。
2. **文件行新增「转到文件」按钮** — 左侧详情栏(GitChangeReview)与右侧变更列表(GitChangesPanel)的每个文件行,hover / 选中时浮现 OpenFile 图标按钮,点击打开该文件的源码预览页签(VS Code 风格)。通路:复用 ChatView 已有的 `openFilePreview`,经 PreviewDetailsPanel / SidePanel 分别下传。
3. **「折叠全部 diff」按钮** — 详情栏「N 个文件已更改」行最右端新增 CollapseAll 图标按钮,一键收起全部已展开的 diff(与右键菜单 COLLAPSE_ALL_DIFFS 同语义)。

## 审阅要点

- 已删除(D)状态的文件磁盘上不存在,「转到文件」按钮渲染为隐形占位(`is-hidden`):不可点,同时保证各行 ± 计数列对齐。
- 右侧文件行是 3 列 CSS grid,新增第 4 个子元素后补了 `grid-auto-flow: column` + `grid-auto-columns: max-content`,否则默认 row 流会把按钮折到第二行。非 git 的会话级 ChangesList 复用同一 class,仅 3 子元素,不受影响。
- 折叠按钮未用 Tailwind `!` important 前缀(v4 下行为不确定),改为专属 CSS 类 `.ace-review-collapse-all-btn`。
- 详情栏原刷新按钮随标题行一并移除(用户明确要求整行干掉);手动刷新仍可从右侧 SidePanel 头部触发,回合结束 / checkout 后的自动失效重拉不受影响。

## 验证

- `pnpm build` 通过;`pnpm test`(前端 Node 纯逻辑测试)全过。
- 用隔离 daemon(独立端口/run-dir + `--static-dir` 指向新 dist)在浏览器逐项实测:标题行消失、两侧「转到文件」均打开源码预览页签、折叠全部一键收起。

🤖 Generated with [Claude Code](https://claude.com/claude-code)