### PR TITLE
feat(desktop): add self-drawn Windows toast fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ Key modules:
 - `daemon_pool`: per-workspace daemon process management.
 - `web_host`: native webview wrapper and bridge binding.
 - `tray_icon_win` and `notifications_win`: Windows tray and notification integration.
+- `custom_toast_win` and `notification_backend_policy`: the self-drawn toast fallback and the backend decision it hangs off.
 
 Detailed behavior is in [docs/desktop-shell/multi-workspace.md](docs/desktop-shell/multi-workspace.md).
 
@@ -285,6 +286,23 @@ daemon 侧 `src/web/pty/`:`PtyBackend` 四实现 — **ConPty**(1809+,GetProcAdd
 
 **ConPTY 必踩坑**:pseudoconsole 子进程的 std 句柄仍按老规则从父进程 PEB 复制 — daemon 被 desktop 以 `CREATE_NO_WINDOW` + NUL std 启动时,cmd 复制到无效 stdin → 读 EOF → 秒退 code 0(实测复现)。修复 = spawn 时 `STARTF_USESTDHANDLES` + 三个 NULL 句柄(node-pty 同款),console 子进程初始化回退绑定 conpty console。该修复同时治好了单测 harness 内的同根伪影(最初误判为受限 Job 杀 conhost);`pty_backend_test.cpp` 的环境探针防御性保留。
 
+### Windows 弹框:系统 toast + 自绘兜底(fix-wintoast-silent-drop)
+
+问题:一批 Win10 机器上 WinToast 的 `initialize()` / `showToast()` 全返回成功,弹框却永远不出现 —— AUMID 的开始菜单快捷方式没建成、通知被系统/单应用/组策略关掉、或被"优化"工具停了通知平台。这些都读不出错误码,单靠返回值永远发现不了。
+
+**三层结构**(全部在 `src/desktop/`):
+1. `notification_backend_policy.{hpp,cpp}` — 纯判定表。输入 `NotificationBackendPreference`(config `desktop.notifications.backend` = `auto`(默认)/ `system` / `custom`)+ `SystemToastSignals`(platform_supported / toasts_enabled_globally / app_toasts_enabled / policy_disabled / runtime_delivery_failed),输出 `System | Custom | None` + reason 文案。`auto` 任一信号变坏就转自绘;`system` 是显式选择,不可用时返回 `None` 而**不是**偷偷换成自绘;`custom` 无条件自绘。
+2. `notifications_win.cpp` — 路由 + 注册表探测(`PushNotifications\ToastEnabled`、`Notifications\Settings\<AUMID>\Enabled`、两条 policy 键的 HKCU/HKLM)。WinToast 代码整体收进 `#ifdef ACECODE_HAS_WINTOAST`,**该文件现在在所有 WIN32 构建里编译**(MinGW/WinLibs 不再退化成 no-op stub,自绘渲染只吃 Win32+GDI)。运行期降级是粘性的:`showToast` 返回 <0 或 `toastFailed()` 回调(WinRT 线程,所以用 `std::atomic` 不用锁)置位后重新判定并改走自绘。
+3. `custom_toast.{hpp,cpp}` + `custom_toast_win.cpp` — 自绘渲染,抄 Electron 的 `win32_desktop_notifications`(MIT):隐藏 controller 窗口持 15ms 动画 timer,工作区右下角一摞 `WS_EX_LAYERED|WS_EX_NOACTIVATE|WS_EX_TOPMOST` 的 `WS_POPUP`,GDI 画进内存 DC 后 `UpdateLayeredWindow(Indirect)` 推给合成器;宽度 ease-in(源点同步左移 = 从屏幕边缘滑出)、alpha ease-out、栈塌陷动画三条曲线。
+
+**两处有意偏离 Electron**:(a) Electron 跑在浏览器 UI 线程上,ACECode 要同时服务 FTXUI 终端(**根本没有 Win32 消息循环**)和 desktop 壳,所以 controller 自带**独立线程 + 自己的消息循环**,`show()` 是 `PostMessage` 异步投递(payload 堆分配,post 失败即 delete);(b) Electron 画不透明矩形,这里画**每像素 alpha 的圆角卡片**(跟随系统深浅色,accent 色缩成左侧竖条)。
+
+**per-pixel alpha 的坑**:GDI 文字/图标输出不写 alpha 字节,直接 `ULW_ALPHA` 会合成出垃圾。`apply_rounded_alpha()` 在每次 draw 末尾重写整个 alpha 平面 —— 圆角矩形内恒 255,四角圆弧 4×4 超采样抗锯齿并按覆盖率**预乘 RGB**(`UpdateLayeredWindow` 要求预乘)。DIB 用负 biHeight 建成 top-down,像素遍历才是自然顺序;改像素前必须 `GdiFlush()`。
+
+其它必知细节:controller 窗口**不能用 HWND_MESSAGE**(收不到 `WM_SETTINGCHANGE`/`WM_DISPLAYCHANGE` 广播,重锚失效,同 tray 的坑);渲染线程起手 `SetThreadDpiAwarenessContext(-4)`(动态取址,按 HANDLE 定型以兼容 MinGW 老头文件),这样终端进程不用改进程级 DPI 感知也能画清楚;鼠标悬停期间**冻结整摞**不回收空位(否则卡片滑到光标下,点击会落到另一条通知上);`shutdown()` 若发现自己就跑在渲染线程上(点击回调里拆通知)就 detach 而不是 join,否则自锁。
+
+纯逻辑(缓动曲线、栈偏移、工作区锚定、DPI 缩放、判定表)在 `tests/desktop/custom_toast_layout_test.cpp` + `notification_backend_policy_test.cpp` 里跨平台跑;GDI 渲染只能靠 `notifications_native_test.cpp` 里 `ACECODE_RUN_NOTIFICATION_SMOKE=1` 门控的两条手动冒烟(系统 toast 一条、强制 `backend=custom` 一条)。
+
 ### Proxy / 抓包
 
 `src/network/proxy_resolver.{hpp,cpp}` (with platform-specific `_posix` / `_win` bodies) injects proxy options into all cpr call sites uniformly. Design: `openspec/changes/respect-system-proxy`.
@@ -404,7 +422,8 @@ Both `main.cpp` and `daemon/worker.cpp` call `proxy_resolver().init(cfg.network)
       "enabled": true,
       "on_question": true,
       "on_completion": true,
-      "suppress_when_focused": true
+      "suppress_when_focused": true,
+      "backend": "auto"
     }
   },
   "saved_models": [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,8 +187,11 @@ set(ACECODE_NATIVE_BRIDGE_SUPPORT_SOURCES
     ${CMAKE_SOURCE_DIR}/src/daemon/platform_posix.cpp
     ${CMAKE_SOURCE_DIR}/src/daemon/platform_windows.cpp
     ${CMAKE_SOURCE_DIR}/src/daemon/runtime_files.cpp
+    ${CMAKE_SOURCE_DIR}/src/desktop/custom_toast.cpp
+    ${CMAKE_SOURCE_DIR}/src/desktop/custom_toast_win.cpp
     ${CMAKE_SOURCE_DIR}/src/desktop/folder_picker_win.cpp
     ${CMAKE_SOURCE_DIR}/src/desktop/locale.cpp
+    ${CMAKE_SOURCE_DIR}/src/desktop/notification_backend_policy.cpp
     ${CMAKE_SOURCE_DIR}/src/desktop/notifications.cpp
     ${CMAKE_SOURCE_DIR}/src/desktop/open_request.cpp
     ${CMAKE_SOURCE_DIR}/src/desktop/open_in_explorer.cpp
@@ -297,25 +300,30 @@ elseif(WIN32)
     # advapi32: restrictive ACL writes in utils/atomic_file.hpp.
     # ws2_32: daemon/runtime_files.cpp port probes.
     # ole32/shell32/user32: native folder picker and clipboard integration.
+    # gdi32/msimg32: the self-drawn toast renderer (layered window + GDI).
+    # winmm: PlaySound for the self-drawn toast.
     target_link_libraries(acecode_native_bridge_support PUBLIC
-        advapi32 ws2_32 ole32 shell32 user32
+        advapi32 ws2_32 ole32 shell32 user32 gdi32 msimg32 winmm
+    )
+    # The Windows backend is always compiled now: it also owns the self-drawn
+    # renderer, which needs nothing beyond Win32 + GDI. WinToast is layered on
+    # top when the toolchain can build it.
+    target_sources(acecode_native_bridge_support PRIVATE
+        ${CMAKE_SOURCE_DIR}/src/desktop/notifications_win.cpp
     )
     if(ACECODE_HAS_WINTOAST)
-        target_sources(acecode_native_bridge_support PRIVATE
-            ${CMAKE_SOURCE_DIR}/src/desktop/notifications_win.cpp
-        )
         target_link_libraries(acecode_native_bridge_support PUBLIC
             unofficial::wintoast::wintoast
         )
+        target_compile_definitions(acecode_native_bridge_support PUBLIC
+            ACECODE_HAS_WINTOAST=1
+        )
     else()
         # WinToast requires Windows SDK WRL headers, which are intentionally
-        # absent from self-contained MinGW/WinLibs toolchains.
-        target_sources(acecode_native_bridge_support PRIVATE
-            ${CMAKE_SOURCE_DIR}/src/desktop/notifications_stub.cpp
-        )
-        target_compile_definitions(acecode_native_bridge_support PUBLIC
-            ACECODE_NOTIFICATION_BACKEND_STUB=1
-        )
+        # absent from self-contained MinGW/WinLibs toolchains. Those builds run
+        # the self-drawn renderer only.
+        message(STATUS "WinToast unavailable; Windows notifications will use "
+                       "the self-drawn toast renderer only.")
     endif()
 else()
     target_sources(acecode_native_bridge_support PRIVATE

--- a/LICENSES/MIT-electron.txt
+++ b/LICENSES/MIT-electron.txt
@@ -1,0 +1,27 @@
+The self-drawn Windows toast renderer in src/desktop/custom_toast.{hpp,cpp} and
+src/desktop/custom_toast_win.cpp is derived from Electron's
+shell/browser/notifications/win/win32_desktop_notifications, which carries the
+license below. The window/stack architecture, the three animation curves and
+several layout decisions follow that implementation.
+
+Copyright (c) Electron contributors
+Copyright (c) 2013-2020 GitHub Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -119,8 +119,26 @@ $env:PATH = "$env:ACECODE_WINLIBS_ROOT\bin;$env:PATH"
 The preset also exports `compile_commands.json`, uses the MinGW vcpkg target
 and host triplets, and limits builds to eight jobs for reliable use in a
 lightweight environment. WinToast is unavailable
-without the Windows SDK, so this MinGW-only build uses the notification stub;
-the normal Windows presets retain native WinToast notifications.
+without the Windows SDK, so this MinGW-only build ships the self-drawn toast
+renderer alone; the normal Windows presets can additionally deliver through the
+OS notification centre.
+
+Notification delivery on Windows is selected by
+`desktop.notifications.backend` in `~/.acecode/config.json`:
+
+| value | behaviour |
+| --- | --- |
+| `"auto"` (default) | Use OS toasts when they are actually deliverable, otherwise fall back to the self-drawn popup. |
+| `"system"` | OS toasts only. No popup at all when the OS path is unusable. |
+| `"custom"` | Always use the self-drawn popup. |
+
+`auto` exists because Windows silently drops toasts on plenty of Windows 10
+machines: WinToast reports success, but the Start Menu shortcut carrying the
+AppUserModelID is missing, notifications were turned off for the app or
+system-wide, group policy forbids them, or a "debloat" tool disabled the
+notification platform. ACECode reads those settings up front and switches to
+the self-drawn popup rather than delivering into a black hole. If toasts still
+never appear on a given machine, set `"custom"` to skip the OS path entirely.
 
 Equivalent manual configuration:
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1385,6 +1385,17 @@ AppConfig load_config() {
                                 cfg.desktop.notifications.suppress_when_focused =
                                     nj["suppress_when_focused"].get<bool>();
                             }
+                            if (nj.contains("backend") && nj["backend"].is_string()) {
+                                const std::string backend =
+                                    nj["backend"].get<std::string>();
+                                if (backend == "auto" || backend == "system" ||
+                                    backend == "custom") {
+                                    cfg.desktop.notifications.backend = backend;
+                                } else {
+                                    LOG_WARN("[config] 'desktop.notifications.backend' "
+                                             "must be auto|system|custom, using auto");
+                                }
+                            }
                         }
                     }
                 }
@@ -1834,6 +1845,8 @@ nlohmann::json build_config_json(const AppConfig& cfg) {
             dnj["on_completion"] = cfg.desktop.notifications.on_completion;
         if (cfg.desktop.notifications.suppress_when_focused != dn_d.suppress_when_focused)
             dnj["suppress_when_focused"] = cfg.desktop.notifications.suppress_when_focused;
+        if (cfg.desktop.notifications.backend != dn_d.backend)
+            dnj["backend"] = cfg.desktop.notifications.backend;
         nlohmann::json deskj = nlohmann::json::object();
         if (cfg.desktop.close_to_tray != desk_d.close_to_tray)
             deskj["close_to_tray"] = cfg.desktop.close_to_tray;

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -363,6 +363,10 @@ struct DesktopNotificationsConfig {
     bool on_question = true;             // AskUserQuestion 触发通知
     bool on_completion = true;           // 回合完成触发通知
     bool suppress_when_focused = true;   // 当前 session 已可见且窗口聚焦时不弹
+    // Windows 弹框后端:"auto"(系统 toast 可用就用,否则自绘)/ "system"
+    // (只用系统 toast)/ "custom"(始终自绘)。其它平台忽略。
+    // 见 src/desktop/notification_backend_policy.hpp。
+    std::string backend = "auto";
 };
 
 struct DesktopConfig {

--- a/src/desktop/custom_toast.cpp
+++ b/src/desktop/custom_toast.cpp
@@ -1,0 +1,120 @@
+#include "custom_toast.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace acecode::desktop::custom_toast {
+namespace {
+
+float clamp_unit(float value) {
+    if (value < 0.0f) return 0.0f;
+    if (value > 1.0f) return 1.0f;
+    return value;
+}
+
+float normalized_time(std::uint32_t elapsed_ms, std::uint32_t duration_ms) {
+    if (duration_ms == 0) return 1.0f;
+    if (elapsed_ms >= duration_ms) return 1.0f;
+    return static_cast<float>(elapsed_ms) / static_cast<float>(duration_ms);
+}
+
+// Decelerating exponential ease normalized to hit exactly 0 and 1 at the ends.
+float exponential_ease(float time) {
+    constexpr float a = -8.0f;
+    return (std::exp(a * time) - 1.0f) / (std::exp(a) - 1.0f);
+}
+
+} // namespace
+
+int scale_for_dpi(int value, unsigned dpi) {
+    if (dpi == 0) dpi = kBaseDpi;
+    const long long scaled =
+        static_cast<long long>(value) * static_cast<long long>(dpi) /
+        static_cast<long long>(kBaseDpi);
+    return static_cast<int>(scaled);
+}
+
+float ease_in_position(std::uint32_t elapsed_ms, std::uint32_t duration_ms) {
+    return clamp_unit(exponential_ease(normalized_time(elapsed_ms, duration_ms)));
+}
+
+float ease_out_position(std::uint32_t elapsed_ms, std::uint32_t duration_ms) {
+    const float time = normalized_time(elapsed_ms, duration_ms);
+    return clamp_unit(1.0f - std::sqrt(1.0f - time * time));
+}
+
+float stack_collapse_position(std::uint32_t elapsed_ms,
+                              std::uint32_t duration_ms) {
+    return clamp_unit(exponential_ease(normalized_time(elapsed_ms, duration_ms)));
+}
+
+unsigned clamp_auto_dismiss_seconds(unsigned raw_seconds) {
+    constexpr unsigned kMin = 6;
+    constexpr unsigned kMax = 30;
+    if (raw_seconds < kMin) return kMin;
+    if (raw_seconds > kMax) return kMax;
+    return raw_seconds;
+}
+
+ToastPlacement compute_toast_placement(const ToastRect& work_area,
+                                       int margin_x,
+                                       int margin_y,
+                                       int width,
+                                       int height,
+                                       int vertical_offset,
+                                       float ease_in) {
+    ToastPlacement placement;
+    const float progress = clamp_unit(ease_in);
+    placement.width =
+        static_cast<int>(std::lround(static_cast<double>(width) * progress));
+    placement.width = std::max(0, std::min(width, placement.width));
+    placement.height = height;
+    // The right edge stays pinned while the width grows, so the card appears
+    // to slide out of the screen edge instead of scaling from its center.
+    placement.x = work_area.right - margin_x - placement.width;
+    placement.y = work_area.bottom - margin_y - vertical_offset - height;
+    return placement;
+}
+
+std::vector<int> compute_stack_offsets(const std::vector<int>& heights,
+                                       int margin) {
+    std::vector<int> offsets;
+    offsets.reserve(heights.size());
+    int cursor = 0;
+    for (int height : heights) {
+        offsets.push_back(cursor);
+        cursor += height + margin;
+    }
+    return offsets;
+}
+
+int fit_body_lines(int available_height, int line_height, int max_lines) {
+    if (line_height <= 0 || max_lines <= 0) return 0;
+    if (available_height < line_height) return 0;
+    const int fits = available_height / line_height;
+    return std::min(fits, max_lines);
+}
+
+} // namespace acecode::desktop::custom_toast
+
+#ifndef _WIN32
+
+namespace acecode::desktop::custom_toast {
+
+bool initialize(const InitOptions& /*options*/) {
+    return false;
+}
+
+bool is_available() {
+    return false;
+}
+
+bool show(const NotifyPayload& /*payload*/) {
+    return false;
+}
+
+void shutdown() {}
+
+} // namespace acecode::desktop::custom_toast
+
+#endif // !_WIN32

--- a/src/desktop/custom_toast.hpp
+++ b/src/desktop/custom_toast.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+// Self-drawn Windows notification toasts.
+//
+// Modeled on Electron's `win32_desktop_notifications` — the renderer Electron
+// used before it moved to WinRT toasts. See LICENSES/MIT-electron.txt.
+// The shape of the solution is the same: one hidden controller window owning a
+// 15 ms animation timer, a bottom-right stack of layered `WS_POPUP` windows
+// drawn with GDI into a memory DC and pushed to the compositor with
+// `UpdateLayeredWindow`, an ease-in on appearance, an alpha ease-out on
+// dismissal, and a collapse animation that closes the gap when a toast in the
+// middle of the stack goes away.
+//
+// Two deliberate departures from Electron:
+//
+//  1. Electron drives the stack from the browser UI thread. ACECode has to
+//     serve the FTXUI terminal UI (no Win32 message pump at all) and the
+//     desktop shell from the same API, so the controller owns a dedicated
+//     thread with its own message loop and `show()` is an async post.
+//  2. Electron paints an opaque rectangle tinted from the DWM accent color.
+//     ACECode paints a rounded card with per-pixel alpha, following the
+//     system light/dark preference, with the accent color reduced to a bar
+//     along the leading edge.
+//
+// Everything below the platform surface is pure arithmetic so it can be unit
+// tested on Linux/macOS CI where no Win32 renderer exists.
+
+#include "notifications.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace acecode::desktop::custom_toast {
+
+// ---------------------------------------------------------------------------
+// Platform surface. Non-Windows builds compile safe no-ops.
+// ---------------------------------------------------------------------------
+
+struct InitOptions {
+    std::string app_name = "ACECode";
+    // Used to pick the monitor the stack is anchored to. May be null.
+    void* activation_window = nullptr;
+    // Play the system notification sound on each toast.
+    bool play_sound = true;
+};
+
+// Starts the controller thread. Safe to call repeatedly; only the first call
+// does work. Returns false when the renderer could not be started.
+bool initialize(const InitOptions& options);
+
+bool is_available();
+
+// Queues one toast. Returns false when the renderer is not running or the
+// queue is saturated. Never blocks on the render thread.
+bool show(const NotifyPayload& payload);
+
+// Dismisses everything on screen and stops the controller thread.
+void shutdown();
+
+// ---------------------------------------------------------------------------
+// Pure layout / animation logic.
+// ---------------------------------------------------------------------------
+
+inline constexpr unsigned kBaseDpi = 96;
+// Toasts beyond this stay queued until a visible slot frees up.
+inline constexpr std::size_t kMaxVisibleToasts = 3;
+inline constexpr std::size_t kMaxQueuedToasts = 32;
+
+inline constexpr std::uint32_t kEaseInDurationMs = 320;
+inline constexpr std::uint32_t kEaseOutDurationMs = 160;
+inline constexpr std::uint32_t kStackCollapseDurationMs = 400;
+
+int scale_for_dpi(int value, unsigned dpi);
+
+// Decelerating exponential ease, matching Electron's curve. Returns 0 at
+// `elapsed_ms == 0` and 1 once the duration has elapsed.
+float ease_in_position(std::uint32_t elapsed_ms, std::uint32_t duration_ms);
+// Accelerating circle ease used for the fade-out alpha ramp.
+float ease_out_position(std::uint32_t elapsed_ms, std::uint32_t duration_ms);
+// Same curve as the ease-in; drives the stack closing its gaps.
+float stack_collapse_position(std::uint32_t elapsed_ms,
+                              std::uint32_t duration_ms);
+
+// SPI_GETMESSAGEDURATION is an accessibility setting and can be absurd in
+// either direction; clamp it to something a notification can live with.
+unsigned clamp_auto_dismiss_seconds(unsigned raw_seconds);
+
+struct ToastRect {
+    int left = 0;
+    int top = 0;
+    int right = 0;
+    int bottom = 0;
+};
+
+struct ToastPlacement {
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height = 0;
+};
+
+// Anchors a toast to the bottom-right corner of `work_area`, `vertical_offset`
+// pixels above the corner. `ease_in` in [0,1] shrinks the width while keeping
+// the right edge pinned, which reads as a slide-in from the screen edge.
+ToastPlacement compute_toast_placement(const ToastRect& work_area,
+                                       int margin_x,
+                                       int margin_y,
+                                       int width,
+                                       int height,
+                                       int vertical_offset,
+                                       float ease_in);
+
+// Bottom-up stack offsets: element i is the distance between the bottom of the
+// work area and the bottom of toast i.
+std::vector<int> compute_stack_offsets(const std::vector<int>& heights,
+                                       int margin);
+
+// Number of body lines that fit into `available_height` given `line_height`,
+// capped at `max_lines`.
+int fit_body_lines(int available_height, int line_height, int max_lines);
+
+} // namespace acecode::desktop::custom_toast

--- a/src/desktop/custom_toast_win.cpp
+++ b/src/desktop/custom_toast_win.cpp
@@ -1,0 +1,1247 @@
+#include "custom_toast.hpp"
+
+#ifdef _WIN32
+
+#include "../utils/encoding.hpp"
+#include "../utils/logger.hpp"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#  define NOMINMAX
+#endif
+#include <windows.h>
+#include <windowsx.h>
+#include <mmsystem.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace acecode::desktop::custom_toast {
+namespace {
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+constexpr UINT kMsgShowToast = WM_APP + 0x21;
+constexpr UINT kMsgQuitLoop = WM_APP + 0x22;
+
+constexpr UINT_PTR kAnimationTimerId = 1;
+constexpr UINT_PTR kDismissTimerId = 1;
+constexpr UINT kAnimationIntervalMs = 15;
+
+constexpr wchar_t kControllerClassName[] = L"ACECodeToastController";
+constexpr wchar_t kToastClassName[] = L"ACECodeToastWindow";
+
+// Layout in device-independent pixels (96 dpi).
+constexpr int kCardWidthDip = 368;
+constexpr int kPaddingDip = 16;
+constexpr int kIconSizeDip = 32;
+constexpr int kIconGapDip = 12;
+constexpr int kCloseSizeDip = 24;
+constexpr int kCloseInsetDip = 6;
+constexpr int kAccentBarDip = 4;
+constexpr int kCornerRadiusDip = 8;
+constexpr int kTitleBodyGapDip = 4;
+constexpr int kStackMarginDip = 12;
+constexpr int kScreenMarginXDip = 16;
+constexpr int kScreenMarginYDip = 16;
+constexpr int kMaxBodyLines = 3;
+
+// ---------------------------------------------------------------------------
+// Small Win32 helpers
+// ---------------------------------------------------------------------------
+
+HMODULE current_module() {
+    HMODULE module = nullptr;
+    ::GetModuleHandleExW(
+        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+            GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+        reinterpret_cast<LPCWSTR>(&current_module),
+        &module);
+    return module ? module : ::GetModuleHandleW(nullptr);
+}
+
+// The FTXUI terminal build never sets a process DPI awareness context, and the
+// desktop shell sets one before its first HWND. Raising awareness for this
+// thread only keeps the toast crisp in both without touching process state.
+// Typed through HANDLE so the file still compiles against toolchains whose
+// headers predate DPI_AWARENESS_CONTEXT (MinGW/WinLibs).
+void enable_thread_dpi_awareness() {
+    using SetThreadDpiAwarenessContextFn = HANDLE(WINAPI*)(HANDLE);
+    HMODULE user32 = ::GetModuleHandleW(L"user32.dll");
+    if (!user32) return;
+    auto setter = reinterpret_cast<SetThreadDpiAwarenessContextFn>(
+        reinterpret_cast<void*>(
+            ::GetProcAddress(user32, "SetThreadDpiAwarenessContext")));
+    // -4 == DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+    if (setter) setter(reinterpret_cast<HANDLE>(static_cast<INT_PTR>(-4)));
+}
+
+unsigned monitor_dpi(HMONITOR monitor) {
+    using GetDpiForMonitorFn = HRESULT(WINAPI*)(HMONITOR, int, UINT*, UINT*);
+    if (monitor) {
+        HMODULE shcore = ::LoadLibraryW(L"shcore.dll");
+        if (shcore) {
+            auto getter = reinterpret_cast<GetDpiForMonitorFn>(
+                reinterpret_cast<void*>(
+                    ::GetProcAddress(shcore, "GetDpiForMonitor")));
+            UINT dpi_x = 0;
+            UINT dpi_y = 0;
+            const bool ok = getter && getter(monitor, 0, &dpi_x, &dpi_y) == S_OK;
+            ::FreeLibrary(shcore);
+            if (ok && dpi_y != 0) return dpi_y;
+        }
+    }
+    HDC screen = ::GetDC(nullptr);
+    unsigned dpi = kBaseDpi;
+    if (screen) {
+        const int value = ::GetDeviceCaps(screen, LOGPIXELSY);
+        if (value > 0) dpi = static_cast<unsigned>(value);
+        ::ReleaseDC(nullptr, screen);
+    }
+    return dpi;
+}
+
+unsigned system_dpi() {
+    HDC screen = ::GetDC(nullptr);
+    unsigned dpi = kBaseDpi;
+    if (screen) {
+        const int value = ::GetDeviceCaps(screen, LOGPIXELSY);
+        if (value > 0) dpi = static_cast<unsigned>(value);
+        ::ReleaseDC(nullptr, screen);
+    }
+    return dpi;
+}
+
+DWORD read_dword_value(HKEY root, const wchar_t* subkey, const wchar_t* name,
+                       DWORD fallback) {
+    HKEY key = nullptr;
+    if (::RegOpenKeyExW(root, subkey, 0, KEY_QUERY_VALUE, &key) !=
+        ERROR_SUCCESS) {
+        return fallback;
+    }
+    DWORD value = 0;
+    DWORD type = 0;
+    DWORD size = sizeof(value);
+    const LONG status = ::RegQueryValueExW(
+        key, name, nullptr, &type, reinterpret_cast<BYTE*>(&value), &size);
+    ::RegCloseKey(key);
+    if (status != ERROR_SUCCESS || type != REG_DWORD) return fallback;
+    return value;
+}
+
+bool system_uses_dark_theme() {
+    // 0 = dark apps. Missing value (Windows 10 pre-1803, Server) means light.
+    return read_dword_value(
+               HKEY_CURRENT_USER,
+               L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\"
+               L"Personalize",
+               L"AppsUseLightTheme", 1) == 0;
+}
+
+COLORREF system_accent_color() {
+    // Same lookup Electron uses: DWM's AccentColor is RGBA, the older
+    // ColorizationColor is BGRA.
+    HKEY key = nullptr;
+    if (::RegOpenKeyExW(HKEY_CURRENT_USER, L"SOFTWARE\\Microsoft\\Windows\\DWM",
+                        0, KEY_QUERY_VALUE, &key) == ERROR_SUCCESS) {
+        DWORD value = 0;
+        DWORD type = 0;
+        DWORD size = sizeof(value);
+        const bool accent =
+            ::RegQueryValueExW(key, L"AccentColor", nullptr, &type,
+                               reinterpret_cast<BYTE*>(&value),
+                               &size) == ERROR_SUCCESS &&
+            type == REG_DWORD;
+        if (!accent) {
+            size = sizeof(value);
+            if (::RegQueryValueExW(key, L"ColorizationColor", nullptr, &type,
+                                   reinterpret_cast<BYTE*>(&value),
+                                   &size) == ERROR_SUCCESS &&
+                type == REG_DWORD) {
+                ::RegCloseKey(key);
+                return RGB(GetBValue(value), GetGValue(value), GetRValue(value));
+            }
+        } else {
+            ::RegCloseKey(key);
+            return RGB(GetRValue(value), GetGValue(value), GetBValue(value));
+        }
+        ::RegCloseKey(key);
+    }
+    return RGB(0x40, 0x7d, 0xd0);
+}
+
+struct ToastPalette {
+    COLORREF background = RGB(0x2b, 0x2b, 0x2b);
+    COLORREF background_hot = RGB(0x36, 0x36, 0x36);
+    COLORREF title = RGB(0xf2, 0xf2, 0xf2);
+    COLORREF body = RGB(0xc4, 0xc4, 0xc4);
+    COLORREF close = RGB(0x9a, 0x9a, 0x9a);
+    COLORREF close_hot = RGB(0xff, 0xff, 0xff);
+    COLORREF accent = RGB(0x40, 0x7d, 0xd0);
+};
+
+ToastPalette make_palette(bool dark, COLORREF accent) {
+    ToastPalette palette;
+    palette.accent = accent;
+    if (dark) {
+        palette.background = RGB(0x24, 0x24, 0x26);
+        palette.background_hot = RGB(0x30, 0x30, 0x33);
+        palette.title = RGB(0xf4, 0xf4, 0xf5);
+        palette.body = RGB(0xbd, 0xbd, 0xc2);
+        palette.close = RGB(0x8d, 0x8d, 0x94);
+        palette.close_hot = RGB(0xff, 0xff, 0xff);
+    } else {
+        palette.background = RGB(0xfb, 0xfb, 0xfd);
+        palette.background_hot = RGB(0xf0, 0xf0, 0xf4);
+        palette.title = RGB(0x1b, 0x1b, 0x1f);
+        palette.body = RGB(0x4a, 0x4a, 0x52);
+        palette.close = RGB(0x6a, 0x6a, 0x74);
+        palette.close_hot = RGB(0x11, 0x11, 0x14);
+    }
+    return palette;
+}
+
+// Coverage (0..255) of one pixel against a rounded rectangle. Only the corner
+// boxes need supersampling; everything else is fully covered.
+int rounded_corner_coverage(int x, int y, int width, int height, int radius) {
+    if (radius <= 0) return 255;
+    int center_x = 0;
+    int center_y = 0;
+    if (x < radius) {
+        center_x = radius;
+    } else if (x >= width - radius) {
+        center_x = width - radius;
+    } else {
+        return 255;
+    }
+    if (y < radius) {
+        center_y = radius;
+    } else if (y >= height - radius) {
+        center_y = height - radius;
+    } else {
+        return 255;
+    }
+
+    constexpr int kSamples = 4;
+    const double radius_sq = static_cast<double>(radius) * radius;
+    int hits = 0;
+    for (int sy = 0; sy < kSamples; ++sy) {
+        const double py = y + (sy + 0.5) / kSamples;
+        for (int sx = 0; sx < kSamples; ++sx) {
+            const double px = x + (sx + 0.5) / kSamples;
+            const double dx = px - center_x;
+            const double dy = py - center_y;
+            if (dx * dx + dy * dy <= radius_sq) ++hits;
+        }
+    }
+    return hits * 255 / (kSamples * kSamples);
+}
+
+HICON load_app_icon(int size) {
+    // acecode.rc.in compiles acecode.ico as IDI_ICON1. Older builds emitted it
+    // as a named resource, newer ones as ordinal 1, so try both.
+    HINSTANCE instance = reinterpret_cast<HINSTANCE>(current_module());
+    if (HICON icon = static_cast<HICON>(::LoadImageW(
+            instance, L"IDI_ICON1", IMAGE_ICON, size, size, LR_DEFAULTCOLOR))) {
+        return icon;
+    }
+    if (HICON icon = static_cast<HICON>(
+            ::LoadImageW(instance, MAKEINTRESOURCEW(1), IMAGE_ICON, size, size,
+                         LR_DEFAULTCOLOR))) {
+        return icon;
+    }
+    if (HICON icon = ::LoadIconW(instance, L"IDI_ICON1")) return icon;
+    if (HICON icon = ::LoadIconW(instance, MAKEINTRESOURCEW(1))) return icon;
+    return nullptr;
+}
+
+class Controller;
+
+// ---------------------------------------------------------------------------
+// One toast card
+// ---------------------------------------------------------------------------
+
+class ToastWindow {
+public:
+    ToastWindow(Controller& controller, NotifyPayload payload)
+        : controller_(controller), payload_(std::move(payload)) {
+        title_ = acecode::utf8_to_wide(payload_.title);
+        body_ = acecode::utf8_to_wide(payload_.body);
+        HDC screen = ::GetDC(nullptr);
+        hdc_ = ::CreateCompatibleDC(screen);
+        if (screen) ::ReleaseDC(nullptr, screen);
+    }
+
+    ~ToastWindow() {
+        if (hdc_) {
+            if (previous_bitmap_) ::SelectObject(hdc_, previous_bitmap_);
+            ::DeleteDC(hdc_);
+        }
+        if (bitmap_) ::DeleteObject(bitmap_);
+        if (icon_) ::DestroyIcon(icon_);
+    }
+
+    ToastWindow(const ToastWindow&) = delete;
+    ToastWindow& operator=(const ToastWindow&) = delete;
+
+    static void register_class(HINSTANCE instance) {
+        WNDCLASSEXW wc{};
+        wc.cbSize = sizeof(wc);
+        wc.lpfnWndProc = &ToastWindow::wnd_proc;
+        wc.lpszClassName = kToastClassName;
+        wc.cbWndExtra = sizeof(ToastWindow*);
+        wc.hInstance = instance;
+        wc.hCursor = ::LoadCursorW(nullptr, IDC_ARROW);
+        ::RegisterClassExW(&wc);
+    }
+
+    static ToastWindow* from(HWND hwnd) {
+        return reinterpret_cast<ToastWindow*>(::GetWindowLongPtrW(hwnd, 0));
+    }
+
+    bool create(HINSTANCE instance) {
+        hwnd_ = ::CreateWindowExW(
+            WS_EX_LAYERED | WS_EX_NOACTIVATE | WS_EX_TOPMOST | WS_EX_TOOLWINDOW,
+            kToastClassName, nullptr, WS_POPUP, 0, 0, 0, 0, nullptr, nullptr,
+            instance, this);
+        return hwnd_ != nullptr;
+    }
+
+    HWND hwnd() const { return hwnd_; }
+    int height() const { return static_cast<int>(size_.cy); }
+    bool highlighted() const { return highlighted_; }
+    bool finished() const { return finished_; }
+    bool animation_active() const {
+        return ease_in_active_ || ease_out_active_ || stack_collapse_active();
+    }
+    int vertical_position() const { return vertical_target_; }
+
+    void pop_up(int vertical_offset) {
+        // Size the card before it joins the stack: the controller derives the
+        // next slot from this toast's height, and a zero height would stack the
+        // following toast straight on top of it for one frame.
+        measure_and_resize();
+        vertical_current_ = vertical_offset;
+        vertical_target_ = vertical_offset;
+        stack_collapse_pos_ = 1.0f;
+        ease_in_start_ = ::GetTickCount();
+        ease_in_active_ = true;
+    }
+
+    void set_vertical_position(int vertical_offset) {
+        if (vertical_offset == vertical_target_) return;
+        // Restart the collapse from wherever the previous one got to, so the
+        // card never jumps when two toasts expire back to back.
+        vertical_current_ += static_cast<int>(
+            (vertical_target_ - vertical_current_) * stack_collapse_pos_);
+        vertical_target_ = vertical_offset;
+        stack_collapse_start_ = ::GetTickCount();
+        stack_collapse_pos_ = 0.0f;
+    }
+
+    // Also drops the cached layout: fonts, DPI and the icon size all move when
+    // the display configuration changes.
+    void invalidate() {
+        needs_redraw_ = true;
+        layout_valid_ = false;
+    }
+
+    // Starts the fade-out. Further input is ignored but mouse messages keep
+    // flowing so the stack does not collapse under the cursor.
+    void dismiss() {
+        if (interactive_) {
+            interactive_ = false;
+            ::KillTimer(hwnd_, kDismissTimerId);
+            if (!ease_out_active_) {
+                ease_out_start_ = ::GetTickCount();
+                ease_out_active_ = true;
+            }
+        }
+    }
+
+    HDWP animate(HDWP hdwp, const ToastRect& work_area, int margin_x,
+                 int margin_y);
+
+private:
+    static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT message, WPARAM wparam,
+                                     LPARAM lparam);
+
+    bool stack_collapse_active() const {
+        return vertical_current_ != vertical_target_;
+    }
+
+    void measure_and_resize();
+    void draw();
+    void apply_rounded_alpha();
+    void push_contents();
+    void schedule_dismissal();
+    void cancel_dismissal();
+    void on_mouse_move(POINT cursor);
+    void on_mouse_leave();
+    void on_click();
+
+    Controller& controller_;
+    NotifyPayload payload_;
+    std::wstring title_;
+    std::wstring body_;
+
+    HWND hwnd_ = nullptr;
+    HDC hdc_ = nullptr;
+    HBITMAP bitmap_ = nullptr;
+    HGDIOBJ previous_bitmap_ = nullptr;
+    void* bits_ = nullptr;
+    HICON icon_ = nullptr;
+    int icon_size_ = 0;
+
+    SIZE size_ = {0, 0};
+    RECT close_rect_ = {0, 0, 0, 0};
+    bool needs_redraw_ = true;
+    bool layout_valid_ = false;
+
+    bool highlighted_ = false;
+    bool close_hot_ = false;
+    bool interactive_ = true;
+    bool finished_ = false;
+
+    bool ease_in_active_ = false;
+    bool ease_out_active_ = false;
+    DWORD ease_in_start_ = 0;
+    DWORD ease_out_start_ = 0;
+    DWORD stack_collapse_start_ = 0;
+    float ease_in_pos_ = 0.0f;
+    float ease_out_pos_ = 0.0f;
+    float stack_collapse_pos_ = 1.0f;
+
+    int vertical_current_ = 0;
+    int vertical_target_ = 0;
+};
+
+// ---------------------------------------------------------------------------
+// Hidden controller window: owns fonts, the animation timer and the stack
+// ---------------------------------------------------------------------------
+
+class Controller {
+public:
+    explicit Controller(InitOptions options) : options_(std::move(options)) {
+        anchor_ = static_cast<HWND>(options_.activation_window);
+    }
+
+    ~Controller() { release_assets(); }
+
+    static void register_class(HINSTANCE instance) {
+        WNDCLASSEXW wc{};
+        wc.cbSize = sizeof(wc);
+        wc.lpfnWndProc = &Controller::wnd_proc;
+        wc.lpszClassName = kControllerClassName;
+        wc.cbWndExtra = sizeof(Controller*);
+        wc.hInstance = instance;
+        ::RegisterClassExW(&wc);
+    }
+
+    static Controller* from(HWND hwnd) {
+        return reinterpret_cast<Controller*>(::GetWindowLongPtrW(hwnd, 0));
+    }
+
+    bool create(HINSTANCE instance) {
+        instance_ = instance;
+        // Not a message-only window on purpose: HWND_MESSAGE windows do not
+        // receive the WM_SETTINGCHANGE / WM_DISPLAYCHANGE broadcasts the stack
+        // needs in order to re-anchor itself.
+        hwnd_ = ::CreateWindowExW(0, kControllerClassName, nullptr, 0, 0, 0, 0, 0,
+                                  nullptr, nullptr, instance, this);
+        return hwnd_ != nullptr;
+    }
+
+    HWND hwnd() const { return hwnd_; }
+    HINSTANCE instance() const { return instance_; }
+    const ToastPalette& palette() const { return palette_; }
+    bool sound_enabled() const { return options_.play_sound; }
+
+    unsigned dpi() {
+        ensure_assets();
+        return dpi_;
+    }
+
+    int dip(int value) { return scale_for_dpi(value, dpi()); }
+
+    HFONT title_font() {
+        ensure_assets();
+        return title_font_;
+    }
+
+    HFONT body_font() {
+        ensure_assets();
+        return body_font_;
+    }
+
+    void start_animation() {
+        if (animating_ || !hwnd_) return;
+        // 15 ms rather than 16: the timer is coarse, so ask for more than 60 Hz
+        // to actually land near it.
+        ::SetTimer(hwnd_, kAnimationTimerId, kAnimationIntervalMs, nullptr);
+        animating_ = true;
+    }
+
+    void enqueue(NotifyPayload payload) {
+        if (queue_.size() >= kMaxQueuedToasts) {
+            LOG_WARN("[notifications] custom toast queue is full, dropping " +
+                     payload.id);
+            return;
+        }
+        queue_.push_back(std::move(payload));
+        drain_queue();
+    }
+
+    void animate_all();
+    void destroy_all();
+    void on_display_change();
+
+private:
+    static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT message, WPARAM wparam,
+                                     LPARAM lparam);
+
+    void ensure_assets();
+    void release_assets();
+    void drain_queue();
+    ToastRect work_area() const;
+
+    InitOptions options_;
+    HWND hwnd_ = nullptr;
+    HWND anchor_ = nullptr;
+    HINSTANCE instance_ = nullptr;
+    bool animating_ = false;
+
+    bool assets_valid_ = false;
+    unsigned dpi_ = kBaseDpi;
+    HFONT title_font_ = nullptr;
+    HFONT body_font_ = nullptr;
+    bool stock_title_font_ = false;
+    bool stock_body_font_ = false;
+    ToastPalette palette_;
+
+    std::vector<std::unique_ptr<ToastWindow>> toasts_;
+    std::vector<NotifyPayload> queue_;
+};
+
+// ---------------------------------------------------------------------------
+// ToastWindow implementation
+// ---------------------------------------------------------------------------
+
+LRESULT CALLBACK ToastWindow::wnd_proc(HWND hwnd, UINT message, WPARAM wparam,
+                                       LPARAM lparam) {
+    switch (message) {
+        case WM_CREATE: {
+            auto* cs = reinterpret_cast<const CREATESTRUCTW*>(lparam);
+            ::SetWindowLongPtrW(hwnd, 0,
+                                reinterpret_cast<LONG_PTR>(cs->lpCreateParams));
+            return 0;
+        }
+        case WM_NCDESTROY:
+            // The controller owns the object; only drop the back pointer here.
+            ::SetWindowLongPtrW(hwnd, 0, 0);
+            return 0;
+        case WM_MOUSEACTIVATE:
+            return MA_NOACTIVATE;
+        case WM_TIMER:
+            if (wparam == kDismissTimerId) {
+                if (auto* toast = from(hwnd)) toast->dismiss();
+                return 0;
+            }
+            break;
+        case WM_MOUSEMOVE:
+            if (auto* toast = from(hwnd)) {
+                POINT cursor = {GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam)};
+                toast->on_mouse_move(cursor);
+            }
+            return 0;
+        case WM_MOUSELEAVE:
+            if (auto* toast = from(hwnd)) toast->on_mouse_leave();
+            return 0;
+        case WM_LBUTTONDOWN:
+            if (auto* toast = from(hwnd)) toast->on_click();
+            return 0;
+        default:
+            break;
+    }
+    return ::DefWindowProcW(hwnd, message, wparam, lparam);
+}
+
+void ToastWindow::on_mouse_move(POINT cursor) {
+    bool changed = false;
+    if (!highlighted_) {
+        highlighted_ = true;
+        changed = true;
+        TRACKMOUSEEVENT tme = {sizeof(tme), TME_LEAVE, hwnd_, 0};
+        ::TrackMouseEvent(&tme);
+    }
+    const bool close_hot = ::PtInRect(&close_rect_, cursor) != FALSE;
+    if (close_hot != close_hot_) {
+        close_hot_ = close_hot;
+        changed = true;
+    }
+    // Hovering holds the toast open; the countdown restarts on mouse leave.
+    if (interactive_) cancel_dismissal();
+    if (changed) {
+        // Hover only repaints — the measured layout is unaffected.
+        draw();
+        push_contents();
+    }
+}
+
+void ToastWindow::on_mouse_leave() {
+    highlighted_ = false;
+    close_hot_ = false;
+    draw();
+    push_contents();
+    if (interactive_ && !ease_in_active_) schedule_dismissal();
+    controller_.start_animation();
+}
+
+void ToastWindow::on_click() {
+    if (!interactive_) return;
+    const bool close_clicked = close_hot_;
+    NotifyPayload payload = payload_;
+    dismiss();
+    controller_.start_animation();
+    if (!close_clicked) {
+        // May run arbitrary application code. It never touches this object.
+        dispatch_notification_activation(payload);
+    }
+}
+
+void ToastWindow::schedule_dismissal() {
+    ULONG duration = 0;
+    if (!::SystemParametersInfoW(SPI_GETMESSAGEDURATION, 0, &duration, 0)) {
+        duration = 0;
+    }
+    const unsigned seconds =
+        clamp_auto_dismiss_seconds(static_cast<unsigned>(duration));
+    ::SetTimer(hwnd_, kDismissTimerId, seconds * 1000, nullptr);
+}
+
+void ToastWindow::cancel_dismissal() {
+    ::KillTimer(hwnd_, kDismissTimerId);
+}
+
+void ToastWindow::measure_and_resize() {
+    if (layout_valid_ || !hdc_) return;
+
+    const int padding = controller_.dip(kPaddingDip);
+    const int bar = controller_.dip(kAccentBarDip);
+    const int icon_size = controller_.dip(kIconSizeDip);
+    const int icon_gap = controller_.dip(kIconGapDip);
+    const int close_size = controller_.dip(kCloseSizeDip);
+    const int close_inset = controller_.dip(kCloseInsetDip);
+    const int title_gap = controller_.dip(kTitleBodyGapDip);
+    const int width = controller_.dip(kCardWidthDip);
+
+    const int text_left = bar + padding + icon_size + icon_gap;
+    const int text_right = width - padding;
+
+    TEXTMETRICW title_metrics = {};
+    HGDIOBJ previous_font = ::SelectObject(hdc_, controller_.title_font());
+    ::GetTextMetricsW(hdc_, &title_metrics);
+
+    TEXTMETRICW body_metrics = {};
+    ::SelectObject(hdc_, controller_.body_font());
+    ::GetTextMetricsW(hdc_, &body_metrics);
+
+    const int body_line_height =
+        std::max(1, static_cast<int>(body_metrics.tmHeight));
+    int body_height = 0;
+    if (!body_.empty()) {
+        RECT measure = {0, 0, std::max(1, text_right - text_left), 0};
+        ::DrawTextW(hdc_, body_.c_str(), static_cast<int>(body_.size()),
+                    &measure,
+                    DT_CALCRECT | DT_WORDBREAK | DT_NOPREFIX | DT_EDITCONTROL);
+        const int lines = fit_body_lines(
+            static_cast<int>(measure.bottom - measure.top), body_line_height,
+            kMaxBodyLines);
+        body_height = std::max(lines, 1) * body_line_height;
+    }
+    if (previous_font) ::SelectObject(hdc_, previous_font);
+
+    int height = padding + static_cast<int>(title_metrics.tmHeight) + padding;
+    if (body_height > 0) height += title_gap + body_height;
+    height = std::max(height, padding * 2 + icon_size);
+
+    close_rect_.right = width - close_inset;
+    close_rect_.left = close_rect_.right - close_size;
+    close_rect_.top = close_inset;
+    close_rect_.bottom = close_rect_.top + close_size;
+
+    if (width != size_.cx || height != size_.cy) {
+        BITMAPINFO info = {};
+        info.bmiHeader.biSize = sizeof(info.bmiHeader);
+        info.bmiHeader.biWidth = width;
+        // Negative height keeps the DIB top-down so the alpha fix-up below can
+        // walk rows in the obvious order.
+        info.bmiHeader.biHeight = -height;
+        info.bmiHeader.biPlanes = 1;
+        info.bmiHeader.biBitCount = 32;
+        info.bmiHeader.biCompression = BI_RGB;
+
+        void* bits = nullptr;
+        HBITMAP bitmap = ::CreateDIBSection(nullptr, &info, DIB_RGB_COLORS,
+                                            &bits, nullptr, 0);
+        if (!bitmap) return;
+        HGDIOBJ previous = ::SelectObject(hdc_, bitmap);
+        if (!previous) {
+            ::DeleteObject(bitmap);
+            return;
+        }
+        if (!previous_bitmap_) previous_bitmap_ = previous;
+        if (bitmap_) ::DeleteObject(bitmap_);
+        bitmap_ = bitmap;
+        bits_ = bits;
+        size_.cx = width;
+        size_.cy = height;
+        needs_redraw_ = true;
+    }
+
+    if (!icon_ || icon_size != icon_size_) {
+        if (icon_) ::DestroyIcon(icon_);
+        icon_ = load_app_icon(icon_size);
+        icon_size_ = icon_size;
+    }
+    layout_valid_ = true;
+}
+
+void ToastWindow::draw() {
+    if (!hdc_ || !bits_ || size_.cx <= 0 || size_.cy <= 0) return;
+
+    const ToastPalette& palette = controller_.palette();
+    const int padding = controller_.dip(kPaddingDip);
+    const int bar = controller_.dip(kAccentBarDip);
+    const int icon_size = controller_.dip(kIconSizeDip);
+    const int icon_gap = controller_.dip(kIconGapDip);
+    const int title_gap = controller_.dip(kTitleBodyGapDip);
+    const int text_left = bar + padding + icon_size + icon_gap;
+    const int text_right = static_cast<int>(size_.cx) - padding;
+
+    RECT card = {0, 0, size_.cx, size_.cy};
+    if (HBRUSH brush = ::CreateSolidBrush(
+            highlighted_ ? palette.background_hot : palette.background)) {
+        ::FillRect(hdc_, &card, brush);
+        ::DeleteObject(brush);
+    }
+    RECT accent_bar = {0, 0, bar, size_.cy};
+    if (HBRUSH brush = ::CreateSolidBrush(palette.accent)) {
+        ::FillRect(hdc_, &accent_bar, brush);
+        ::DeleteObject(brush);
+    }
+
+    if (icon_) {
+        ::DrawIconEx(hdc_, bar + padding, padding, icon_, icon_size, icon_size,
+                     0, nullptr, DI_NORMAL);
+    }
+
+    ::SetBkMode(hdc_, TRANSPARENT);
+
+    TEXTMETRICW title_metrics = {};
+    HGDIOBJ previous_font = ::SelectObject(hdc_, controller_.title_font());
+    ::GetTextMetricsW(hdc_, &title_metrics);
+    ::SetTextColor(hdc_, palette.title);
+    RECT title_rect = {text_left, padding, close_rect_.left - padding / 2,
+                       padding + title_metrics.tmHeight};
+    if (!title_.empty()) {
+        ::DrawTextW(hdc_, title_.c_str(), static_cast<int>(title_.size()),
+                    &title_rect,
+                    DT_SINGLELINE | DT_END_ELLIPSIS | DT_NOPREFIX);
+    }
+
+    if (!body_.empty()) {
+        ::SelectObject(hdc_, controller_.body_font());
+        ::SetTextColor(hdc_, palette.body);
+        RECT body_rect = {text_left, title_rect.bottom + title_gap, text_right,
+                          size_.cy - padding};
+        ::DrawTextW(hdc_, body_.c_str(), static_cast<int>(body_.size()),
+                    &body_rect,
+                    DT_LEFT | DT_WORDBREAK | DT_NOPREFIX | DT_END_ELLIPSIS |
+                        DT_EDITCONTROL);
+    }
+
+    const wchar_t close_glyph = L'\x2715';
+    ::SelectObject(hdc_, controller_.body_font());
+    ::SetTextColor(hdc_, close_hot_ ? palette.close_hot : palette.close);
+    RECT close_rect = close_rect_;
+    ::DrawTextW(hdc_, &close_glyph, 1, &close_rect,
+                DT_SINGLELINE | DT_CENTER | DT_VCENTER | DT_NOPREFIX);
+    if (previous_font) ::SelectObject(hdc_, previous_font);
+
+    apply_rounded_alpha();
+    needs_redraw_ = false;
+}
+
+void ToastWindow::apply_rounded_alpha() {
+    if (!bits_) return;
+    // GDI drawing leaves the alpha byte undefined, so the layered window would
+    // composite garbage. Rewrite the whole alpha plane here: opaque inside the
+    // rounded rectangle, antialiased across the corner arcs, and premultiplied
+    // where coverage is partial because UpdateLayeredWindow expects that.
+    ::GdiFlush();
+    const int width = static_cast<int>(size_.cx);
+    const int height = static_cast<int>(size_.cy);
+    const int radius =
+        std::min({controller_.dip(kCornerRadiusDip), width / 2, height / 2});
+    auto* pixels = static_cast<BYTE*>(bits_);
+    for (int y = 0; y < height; ++y) {
+        BYTE* row = pixels + static_cast<size_t>(y) * width * 4;
+        for (int x = 0; x < width; ++x) {
+            BYTE* pixel = row + static_cast<size_t>(x) * 4;
+            const int coverage =
+                rounded_corner_coverage(x, y, width, height, radius);
+            if (coverage >= 255) {
+                pixel[3] = 255;
+                continue;
+            }
+            pixel[0] = static_cast<BYTE>(pixel[0] * coverage / 255);
+            pixel[1] = static_cast<BYTE>(pixel[1] * coverage / 255);
+            pixel[2] = static_cast<BYTE>(pixel[2] * coverage / 255);
+            pixel[3] = static_cast<BYTE>(coverage);
+        }
+    }
+}
+
+void ToastWindow::push_contents() {
+    if (!hwnd_ || !::IsWindowVisible(hwnd_)) return;
+    RECT rect = {};
+    if (!::GetWindowRect(hwnd_, &rect)) return;
+    POINT source = {size_.cx - (rect.right - rect.left), 0L};
+    if (source.x < 0) source.x = 0;
+    SIZE size = {rect.right - rect.left, rect.bottom - rect.top};
+    BLENDFUNCTION blend = {AC_SRC_OVER, 0,
+                           static_cast<BYTE>(std::lround(
+                               255.0 * (1.0 - ease_out_pos_))),
+                           AC_SRC_ALPHA};
+    ::UpdateLayeredWindow(hwnd_, nullptr, nullptr, &size, hdc_, &source, 0,
+                          &blend, ULW_ALPHA);
+}
+
+HDWP ToastWindow::animate(HDWP hdwp, const ToastRect& work_area, int margin_x,
+                          int margin_y) {
+    measure_and_resize();
+    if (needs_redraw_) draw();
+    if (!bitmap_) return hdwp;
+
+    const DWORD now = ::GetTickCount();
+
+    if (ease_in_active_) {
+        ease_in_pos_ = ease_in_position(now - ease_in_start_, kEaseInDurationMs);
+        if (ease_in_pos_ >= 1.0f) {
+            ease_in_active_ = false;
+            if (interactive_ && !highlighted_) schedule_dismissal();
+        }
+    }
+    if (ease_out_active_) {
+        ease_out_pos_ =
+            ease_out_position(now - ease_out_start_, kEaseOutDurationMs);
+        if (ease_out_pos_ >= 1.0f) ease_out_active_ = false;
+    }
+    if (stack_collapse_active()) {
+        stack_collapse_pos_ = stack_collapse_position(now - stack_collapse_start_,
+                                                      kStackCollapseDurationMs);
+    }
+
+    const int collapse_offset = static_cast<int>(
+        (vertical_target_ - vertical_current_) * stack_collapse_pos_);
+    const int vertical_offset = vertical_current_ + collapse_offset;
+    if (stack_collapse_pos_ >= 1.0f) vertical_current_ = vertical_target_;
+
+    const ToastPlacement placement =
+        compute_toast_placement(work_area, margin_x, margin_y,
+                                static_cast<int>(size_.cx),
+                                static_cast<int>(size_.cy), vertical_offset,
+                                ease_in_pos_);
+
+    UINT flags = SWP_NOACTIVATE | SWP_SHOWWINDOW | SWP_NOREDRAW | SWP_NOCOPYBITS;
+    const bool fading_done = !ease_out_active_ && ease_out_pos_ >= 1.0f;
+    if (fading_done) {
+        flags &= ~static_cast<UINT>(SWP_SHOWWINDOW);
+        flags |= SWP_HIDEWINDOW;
+        finished_ = true;
+        highlighted_ = false;
+    }
+
+    // Reveal the card from its right edge: the destination width grows while
+    // the source origin walks back toward zero, so the card looks like it
+    // slides out of the screen border instead of scaling in place.
+    POINT source = {size_.cx - placement.width, 0};
+    if (source.x < 0) source.x = 0;
+    POINT destination = {placement.x, placement.y};
+    SIZE size = {placement.width, placement.height};
+    BLENDFUNCTION blend = {AC_SRC_OVER, 0,
+                           static_cast<BYTE>(std::lround(
+                               255.0 * (1.0 - ease_out_pos_))),
+                           AC_SRC_ALPHA};
+
+    UPDATELAYEREDWINDOWINFO update = {};
+    update.cbSize = sizeof(update);
+    update.hdcDst = nullptr;
+    update.pptDst = &destination;
+    update.psize = &size;
+    update.hdcSrc = hdc_;
+    update.pptSrc = &source;
+    update.crKey = 0;
+    update.pblend = &blend;
+    update.dwFlags = ULW_ALPHA;
+    update.prcDirty = nullptr;
+    // Fails while the width is still zero at the start of the ease-in; the
+    // DeferWindowPos below is what actually places the window in that frame.
+    ::UpdateLayeredWindowIndirect(hwnd_, &update);
+
+    return ::DeferWindowPos(hdwp, hwnd_, HWND_TOPMOST, destination.x,
+                            destination.y, size.cx, size.cy, flags);
+}
+
+// ---------------------------------------------------------------------------
+// Controller implementation
+// ---------------------------------------------------------------------------
+
+LRESULT CALLBACK Controller::wnd_proc(HWND hwnd, UINT message, WPARAM wparam,
+                                      LPARAM lparam) {
+    switch (message) {
+        case WM_CREATE: {
+            auto* cs = reinterpret_cast<const CREATESTRUCTW*>(lparam);
+            ::SetWindowLongPtrW(hwnd, 0,
+                                reinterpret_cast<LONG_PTR>(cs->lpCreateParams));
+            return 0;
+        }
+        case WM_TIMER:
+            if (wparam == kAnimationTimerId) {
+                if (auto* controller = from(hwnd)) controller->animate_all();
+                return 0;
+            }
+            break;
+        case WM_DISPLAYCHANGE:
+            if (auto* controller = from(hwnd)) controller->on_display_change();
+            break;
+        case WM_SETTINGCHANGE:
+            if (wparam == SPI_SETWORKAREA || wparam == SPI_SETNONCLIENTMETRICS) {
+                if (auto* controller = from(hwnd)) controller->on_display_change();
+            }
+            break;
+        case kMsgShowToast: {
+            std::unique_ptr<NotifyPayload> payload(
+                reinterpret_cast<NotifyPayload*>(lparam));
+            if (auto* controller = from(hwnd)) {
+                if (payload) controller->enqueue(std::move(*payload));
+            }
+            return 0;
+        }
+        case kMsgQuitLoop:
+            if (auto* controller = from(hwnd)) controller->destroy_all();
+            ::PostQuitMessage(0);
+            return 0;
+        default:
+            break;
+    }
+    return ::DefWindowProcW(hwnd, message, wparam, lparam);
+}
+
+void Controller::ensure_assets() {
+    if (assets_valid_) return;
+    assets_valid_ = true;
+
+    HMONITOR monitor = nullptr;
+    if (anchor_ && ::IsWindow(anchor_)) {
+        monitor = ::MonitorFromWindow(anchor_, MONITOR_DEFAULTTONEAREST);
+    }
+    if (!monitor) {
+        POINT origin = {0, 0};
+        monitor = ::MonitorFromPoint(origin, MONITOR_DEFAULTTOPRIMARY);
+    }
+    dpi_ = monitor_dpi(monitor);
+    palette_ = make_palette(system_uses_dark_theme(), system_accent_color());
+
+    if (body_font_ && !stock_body_font_) ::DeleteObject(body_font_);
+    if (title_font_ && !stock_title_font_) ::DeleteObject(title_font_);
+    body_font_ = nullptr;
+    title_font_ = nullptr;
+    stock_body_font_ = false;
+    stock_title_font_ = false;
+
+    NONCLIENTMETRICSW metrics = {};
+    metrics.cbSize = sizeof(metrics);
+    if (::SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(metrics),
+                                &metrics, 0)) {
+        const unsigned measured = system_dpi();
+        const unsigned base = measured == 0 ? kBaseDpi : measured;
+        LOGFONTW body = metrics.lfMessageFont;
+        body.lfHeight = ::MulDiv(body.lfHeight, static_cast<int>(dpi_),
+                                 static_cast<int>(base));
+        LOGFONTW title = body;
+        title.lfHeight = ::MulDiv(title.lfHeight, 108, 100);
+        title.lfWeight = FW_SEMIBOLD;
+        body_font_ = ::CreateFontIndirectW(&body);
+        title_font_ = ::CreateFontIndirectW(&title);
+    }
+
+    // A missing metrics call or a failed font creation must not leave the DC
+    // without a font; text would then render at an unpredictable size.
+    HFONT stock = static_cast<HFONT>(::GetStockObject(DEFAULT_GUI_FONT));
+    if (!body_font_) body_font_ = stock;
+    if (!title_font_) title_font_ = stock;
+    stock_body_font_ = body_font_ == stock;
+    stock_title_font_ = title_font_ == stock;
+}
+
+void Controller::release_assets() {
+    // Stock objects are owned by GDI and must never be deleted.
+    if (body_font_ && !stock_body_font_) ::DeleteObject(body_font_);
+    if (title_font_ && !stock_title_font_) ::DeleteObject(title_font_);
+    body_font_ = nullptr;
+    title_font_ = nullptr;
+    stock_body_font_ = false;
+    stock_title_font_ = false;
+    assets_valid_ = false;
+}
+
+void Controller::on_display_change() {
+    release_assets();
+    for (auto& toast : toasts_) toast->invalidate();
+    start_animation();
+}
+
+ToastRect Controller::work_area() const {
+    HMONITOR monitor = nullptr;
+    if (anchor_ && ::IsWindow(anchor_)) {
+        monitor = ::MonitorFromWindow(anchor_, MONITOR_DEFAULTTONEAREST);
+    }
+    if (!monitor) {
+        POINT origin = {0, 0};
+        monitor = ::MonitorFromPoint(origin, MONITOR_DEFAULTTOPRIMARY);
+    }
+    // LONG -> int would be a narrowing conversion inside a braced initializer,
+    // which MSVC rejects outright; spell the casts out.
+    auto to_toast_rect = [](const RECT& rect) {
+        return ToastRect{static_cast<int>(rect.left), static_cast<int>(rect.top),
+                         static_cast<int>(rect.right),
+                         static_cast<int>(rect.bottom)};
+    };
+
+    MONITORINFO info = {};
+    info.cbSize = sizeof(info);
+    if (monitor && ::GetMonitorInfoW(monitor, &info)) {
+        return to_toast_rect(info.rcWork);
+    }
+    RECT rect = {};
+    if (::SystemParametersInfoW(SPI_GETWORKAREA, 0, &rect, 0)) {
+        return to_toast_rect(rect);
+    }
+    return {0, 0, ::GetSystemMetrics(SM_CXSCREEN),
+            ::GetSystemMetrics(SM_CYSCREEN)};
+}
+
+void Controller::drain_queue() {
+    while (toasts_.size() < kMaxVisibleToasts && !queue_.empty()) {
+        NotifyPayload payload = std::move(queue_.front());
+        queue_.erase(queue_.begin());
+
+        auto toast = std::make_unique<ToastWindow>(*this, std::move(payload));
+        if (!toast->create(instance_)) {
+            LOG_WARN("[notifications] custom toast window creation failed");
+            continue;
+        }
+
+        int offset = 0;
+        if (!toasts_.empty()) {
+            ToastWindow& last = *toasts_.back();
+            offset = last.vertical_position() + last.height() +
+                     dip(kStackMarginDip);
+        }
+        toast->pop_up(offset);
+        toasts_.push_back(std::move(toast));
+
+        if (options_.play_sound) {
+            ::PlaySoundW(L"Notification.Default", nullptr,
+                         SND_ALIAS | SND_ASYNC | SND_NODEFAULT);
+        }
+        start_animation();
+    }
+}
+
+void Controller::animate_all() {
+    const ToastRect area = work_area();
+    const int margin_x = dip(kScreenMarginXDip);
+    const int margin_y = dip(kScreenMarginYDip);
+
+    bool keep_animating = false;
+    if (!toasts_.empty()) {
+        HDWP hdwp = ::BeginDeferWindowPos(static_cast<int>(toasts_.size()));
+        for (auto& toast : toasts_) {
+            hdwp = toast->animate(hdwp, area, margin_x, margin_y);
+            keep_animating |= toast->animation_active();
+            if (!hdwp) break;
+        }
+        if (hdwp) ::EndDeferWindowPos(hdwp);
+    }
+
+    if (!keep_animating && hwnd_) {
+        ::KillTimer(hwnd_, kAnimationTimerId);
+        animating_ = false;
+    }
+
+    // While the cursor rests on a toast the stack stays frozen: reclaiming the
+    // slot of an expired neighbour would slide a different card under the
+    // pointer and turn a click into the wrong action.
+    const bool frozen = std::any_of(
+        toasts_.begin(), toasts_.end(),
+        [](const std::unique_ptr<ToastWindow>& toast) {
+            return toast->highlighted();
+        });
+    if (!frozen) {
+        for (auto it = toasts_.begin(); it != toasts_.end();) {
+            if ((*it)->finished()) {
+                ::DestroyWindow((*it)->hwnd());
+                it = toasts_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        int offset = 0;
+        for (auto& toast : toasts_) {
+            toast->set_vertical_position(offset);
+            offset += toast->height() + dip(kStackMarginDip);
+            if (toast->animation_active()) keep_animating = true;
+        }
+        if (keep_animating) start_animation();
+    }
+
+    drain_queue();
+}
+
+void Controller::destroy_all() {
+    for (auto& toast : toasts_) {
+        if (toast->hwnd()) ::DestroyWindow(toast->hwnd());
+    }
+    toasts_.clear();
+    queue_.clear();
+    if (hwnd_ && animating_) {
+        ::KillTimer(hwnd_, kAnimationTimerId);
+        animating_ = false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Render thread + public surface
+// ---------------------------------------------------------------------------
+
+std::mutex g_mutex;
+bool g_running = false;
+HWND g_controller_hwnd = nullptr;
+std::thread g_thread;
+
+void render_thread_main(InitOptions options, std::promise<HWND> ready) {
+    enable_thread_dpi_awareness();
+
+    HINSTANCE instance = reinterpret_cast<HINSTANCE>(current_module());
+    if (!instance) {
+        ready.set_value(nullptr);
+        return;
+    }
+    Controller::register_class(instance);
+    ToastWindow::register_class(instance);
+
+    Controller controller(std::move(options));
+    if (!controller.create(instance)) {
+        LOG_WARN("[notifications] custom toast controller window failed");
+        ready.set_value(nullptr);
+        return;
+    }
+    ready.set_value(controller.hwnd());
+
+    MSG message;
+    while (::GetMessageW(&message, nullptr, 0, 0) > 0) {
+        ::TranslateMessage(&message);
+        ::DispatchMessageW(&message);
+    }
+    controller.destroy_all();
+}
+
+} // namespace
+
+bool initialize(const InitOptions& options) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (g_running) return true;
+
+    std::promise<HWND> ready;
+    std::future<HWND> future = ready.get_future();
+    std::thread worker(render_thread_main, options, std::move(ready));
+
+    HWND hwnd = nullptr;
+    if (future.wait_for(std::chrono::seconds(5)) == std::future_status::ready) {
+        hwnd = future.get();
+    }
+    if (!hwnd) {
+        // The thread either failed early or is wedged. A failed start is
+        // non-fatal, so let it go rather than blocking startup on a join.
+        worker.detach();
+        LOG_WARN("[notifications] self-drawn toast renderer failed to start");
+        return false;
+    }
+
+    g_controller_hwnd = hwnd;
+    g_thread = std::move(worker);
+    g_running = true;
+    LOG_INFO("[notifications] self-drawn toast renderer started");
+    return true;
+}
+
+bool is_available() {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    return g_running;
+}
+
+bool show(const NotifyPayload& payload) {
+    HWND hwnd = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        if (!g_running) return false;
+        hwnd = g_controller_hwnd;
+    }
+    auto* copy = new NotifyPayload(payload);
+    if (!::PostMessageW(hwnd, kMsgShowToast, 0,
+                        reinterpret_cast<LPARAM>(copy))) {
+        delete copy;
+        return false;
+    }
+    return true;
+}
+
+void shutdown() {
+    std::thread worker;
+    HWND hwnd = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        if (!g_running) return;
+        g_running = false;
+        hwnd = g_controller_hwnd;
+        g_controller_hwnd = nullptr;
+        worker = std::move(g_thread);
+    }
+    if (hwnd) ::PostMessageW(hwnd, kMsgQuitLoop, 0, 0);
+    if (!worker.joinable()) return;
+    // A click handler runs on the render thread and may tear notifications
+    // down from there; joining ourselves would deadlock.
+    if (worker.get_id() == std::this_thread::get_id()) {
+        worker.detach();
+        return;
+    }
+    worker.join();
+}
+
+} // namespace acecode::desktop::custom_toast
+
+#endif // _WIN32

--- a/src/desktop/main.cpp
+++ b/src/desktop/main.cpp
@@ -1139,6 +1139,7 @@ int main(int argc, char** argv) {
     notification_options.app_name = "ACECode Desktop";
 #ifdef _WIN32
     notification_options.application_id = "ACECode.ACECode.Desktop.1";
+    notification_options.backend = desktop_cfg.desktop.notifications.backend;
 #endif
     notification_options.activation_window = host.native_window();
     const bool notifications_ok = init_notifications(notification_options);

--- a/src/desktop/notification_backend_policy.cpp
+++ b/src/desktop/notification_backend_policy.cpp
@@ -1,0 +1,104 @@
+#include "notification_backend_policy.hpp"
+
+#include <algorithm>
+#include <cctype>
+
+namespace acecode::desktop {
+namespace {
+
+std::string normalize(std::string_view value) {
+    std::string out;
+    out.reserve(value.size());
+    for (char ch : value) {
+        const auto uch = static_cast<unsigned char>(ch);
+        if (std::isspace(uch)) continue;
+        out.push_back(static_cast<char>(std::tolower(uch)));
+    }
+    return out;
+}
+
+} // namespace
+
+NotificationBackendPreference parse_notification_backend_preference(
+    std::string_view value,
+    NotificationBackendPreference fallback) {
+    const std::string normalized = normalize(value);
+    if (normalized == "auto") return NotificationBackendPreference::Auto;
+    if (normalized == "system" || normalized == "os" ||
+        normalized == "wintoast") {
+        return NotificationBackendPreference::System;
+    }
+    if (normalized == "custom" || normalized == "builtin" ||
+        normalized == "self") {
+        return NotificationBackendPreference::Custom;
+    }
+    return fallback;
+}
+
+std::string_view notification_backend_preference_value(
+    NotificationBackendPreference preference) {
+    switch (preference) {
+        case NotificationBackendPreference::Auto:
+            return "auto";
+        case NotificationBackendPreference::System:
+            return "system";
+        case NotificationBackendPreference::Custom:
+            return "custom";
+    }
+    return "auto";
+}
+
+NotificationBackendDecision decide_notification_backend(
+    NotificationBackendPreference preference,
+    const SystemToastSignals& signals) {
+    if (preference == NotificationBackendPreference::Custom) {
+        return {NotificationBackendChoice::Custom, "configured backend=custom"};
+    }
+
+    if (preference == NotificationBackendPreference::System) {
+        // An explicit request for OS toasts is honored verbatim: falling back
+        // to a self-drawn window here would defeat the reason for asking.
+        if (!signals.platform_supported) {
+            return {NotificationBackendChoice::None,
+                    "configured backend=system but the OS toast backend is "
+                    "unavailable"};
+        }
+        return {NotificationBackendChoice::System, "configured backend=system"};
+    }
+
+    if (!signals.platform_supported) {
+        return {NotificationBackendChoice::Custom,
+                "OS toast backend unavailable"};
+    }
+    if (signals.runtime_delivery_failed) {
+        return {NotificationBackendChoice::Custom,
+                "OS toast delivery failed earlier in this process"};
+    }
+    if (signals.policy_disabled) {
+        return {NotificationBackendChoice::Custom,
+                "OS toasts disabled by group policy"};
+    }
+    if (!signals.toasts_enabled_globally) {
+        return {NotificationBackendChoice::Custom,
+                "OS toasts disabled system-wide"};
+    }
+    if (!signals.app_toasts_enabled) {
+        return {NotificationBackendChoice::Custom,
+                "OS toasts disabled for this application"};
+    }
+    return {NotificationBackendChoice::System, "OS toast backend available"};
+}
+
+const char* notification_backend_choice_name(NotificationBackendChoice choice) {
+    switch (choice) {
+        case NotificationBackendChoice::None:
+            return "none";
+        case NotificationBackendChoice::System:
+            return "system";
+        case NotificationBackendChoice::Custom:
+            return "custom";
+    }
+    return "none";
+}
+
+} // namespace acecode::desktop

--- a/src/desktop/notification_backend_policy.hpp
+++ b/src/desktop/notification_backend_policy.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+// Chooses between the OS toast backend (WinToast / Action Center) and the
+// self-drawn toast window.
+//
+// Motivation: on a non-trivial share of Windows 10 machines WinToast reports a
+// successful `initialize()` *and* a successful `showToast()` while nothing ever
+// appears on screen. The notification is dropped downstream by the OS — the
+// Start Menu shortcut carrying the AppUserModelID is missing, notifications are
+// switched off for the app or globally, a "debloat" utility disabled the
+// notification platform, or group policy forbids toasts. None of that is
+// observable through WinToast's return values, so the failure is silent.
+//
+// The decision below turns those OS-side settings into an explicit signal set
+// so the caller can pick the self-drawn renderer *before* delivering a
+// notification into a black hole. Keeping it as a pure function makes the
+// policy testable on every platform.
+
+#include <string>
+#include <string_view>
+
+namespace acecode::desktop {
+
+// `config.desktop.notifications.backend`.
+enum class NotificationBackendPreference {
+    // Prefer OS toasts, fall back to the self-drawn renderer when the OS path
+    // is unavailable or suppressed.
+    Auto,
+    // OS toasts only. When the OS path is unusable no notification is shown —
+    // an explicit choice is not silently overridden.
+    System,
+    // Always use the self-drawn renderer.
+    Custom,
+};
+
+NotificationBackendPreference parse_notification_backend_preference(
+    std::string_view value,
+    NotificationBackendPreference fallback = NotificationBackendPreference::Auto);
+
+std::string_view notification_backend_preference_value(
+    NotificationBackendPreference preference);
+
+// Everything the platform layer can observe about the OS toast pipeline.
+// Defaults describe "the OS would deliver a toast" so a probe that cannot read
+// a given setting stays neutral instead of forcing a fallback.
+struct SystemToastSignals {
+    // WinToast compiled in, the Windows version supports toasts, and
+    // initialization succeeded.
+    bool platform_supported = false;
+    // HKCU\...\PushNotifications\ToastEnabled
+    bool toasts_enabled_globally = true;
+    // HKCU\...\Notifications\Settings\<AUMID>\Enabled
+    bool app_toasts_enabled = true;
+    // Group policy (NoToastApplicationNotification / DisableNotificationCenter).
+    bool policy_disabled = false;
+    // Set once a delivery attempt failed at runtime. Sticky for the process.
+    bool runtime_delivery_failed = false;
+};
+
+enum class NotificationBackendChoice {
+    None,
+    System,
+    Custom,
+};
+
+struct NotificationBackendDecision {
+    NotificationBackendChoice choice = NotificationBackendChoice::None;
+    // Short English phrase for the startup log line.
+    std::string reason;
+};
+
+NotificationBackendDecision decide_notification_backend(
+    NotificationBackendPreference preference,
+    const SystemToastSignals& signals);
+
+const char* notification_backend_choice_name(NotificationBackendChoice choice);
+
+} // namespace acecode::desktop

--- a/src/desktop/notifications.hpp
+++ b/src/desktop/notifications.hpp
@@ -43,6 +43,9 @@ struct NotificationInitOptions {
     std::string application_id;
     // Windows: HWND. macOS Desktop: NSWindow*. Unsupported platforms: ignored.
     void* activation_window = nullptr;
+    // Windows only: "auto" | "system" | "custom", see
+    // notification_backend_policy.hpp. Other platforms ignore it.
+    std::string backend = "auto";
 };
 
 using ClickHandler = std::function<void(const NotifyPayload& payload)>;

--- a/src/desktop/notifications_win.cpp
+++ b/src/desktop/notifications_win.cpp
@@ -2,6 +2,9 @@
 
 #ifdef _WIN32
 
+#include "custom_toast.hpp"
+#include "notification_backend_policy.hpp"
+
 #include "../config/config.hpp"
 #include "../utils/atomic_file.hpp"
 #include "../utils/encoding.hpp"
@@ -15,8 +18,12 @@
 #  define NOMINMAX
 #endif
 #include <windows.h>
-#include <wintoastlib.h>
 
+#ifdef ACECODE_HAS_WINTOAST
+#  include <wintoastlib.h>
+#endif
+
+#include <atomic>
 #include <exception>
 #include <filesystem>
 #include <mutex>
@@ -28,6 +35,107 @@ namespace {
 
 std::mutex g_backend_mu;
 bool g_initialized = false;
+NotificationBackendPreference g_preference = NotificationBackendPreference::Auto;
+NotificationBackendChoice g_choice = NotificationBackendChoice::None;
+SystemToastSignals g_signals;
+std::string g_app_name = "ACECode";
+void* g_activation_window = nullptr;
+
+// Set from WinToast's failure callback, which runs on a WinRT thread while the
+// facade mutex may be held by the caller that queued the toast. Atomic so the
+// callback never has to take that lock.
+std::atomic<bool> g_system_delivery_failed{false};
+
+// ---------------------------------------------------------------------------
+// Registry probes
+//
+// WinToast reports success for a toast the OS then drops on the floor, which is
+// exactly the Windows 10 failure users see: no popup, no error, nothing in the
+// Action Center. These are the settings that silently swallow toasts.
+// ---------------------------------------------------------------------------
+
+bool read_dword(HKEY root, const wchar_t* subkey, const wchar_t* name,
+                DWORD* out) {
+    HKEY key = nullptr;
+    if (::RegOpenKeyExW(root, subkey, 0, KEY_QUERY_VALUE, &key) !=
+        ERROR_SUCCESS) {
+        return false;
+    }
+    DWORD value = 0;
+    DWORD type = 0;
+    DWORD size = sizeof(value);
+    const LONG status = ::RegQueryValueExW(
+        key, name, nullptr, &type, reinterpret_cast<BYTE*>(&value), &size);
+    ::RegCloseKey(key);
+    if (status != ERROR_SUCCESS || type != REG_DWORD) return false;
+    *out = value;
+    return true;
+}
+
+bool toast_policy_disabled() {
+    DWORD value = 0;
+    if (read_dword(HKEY_CURRENT_USER,
+                   L"SOFTWARE\\Policies\\Microsoft\\Windows\\Explorer",
+                   L"DisableNotificationCenter", &value) &&
+        value != 0) {
+        return true;
+    }
+    if (read_dword(HKEY_LOCAL_MACHINE,
+                   L"SOFTWARE\\Policies\\Microsoft\\Windows\\Explorer",
+                   L"DisableNotificationCenter", &value) &&
+        value != 0) {
+        return true;
+    }
+    if (read_dword(HKEY_CURRENT_USER,
+                   L"SOFTWARE\\Policies\\Microsoft\\Windows\\CurrentVersion\\"
+                   L"PushNotifications",
+                   L"NoToastApplicationNotification", &value) &&
+        value != 0) {
+        return true;
+    }
+    if (read_dword(HKEY_LOCAL_MACHINE,
+                   L"SOFTWARE\\Policies\\Microsoft\\Windows\\CurrentVersion\\"
+                   L"PushNotifications",
+                   L"NoToastApplicationNotification", &value) &&
+        value != 0) {
+        return true;
+    }
+    return false;
+}
+
+bool toasts_enabled_globally() {
+    DWORD value = 0;
+    if (read_dword(HKEY_CURRENT_USER,
+                   L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\"
+                   L"PushNotifications",
+                   L"ToastEnabled", &value)) {
+        return value != 0;
+    }
+    // Absent on Windows versions that predate the setting; treat as enabled.
+    return true;
+}
+
+bool app_toasts_enabled(const std::string& application_id) {
+    if (application_id.empty()) return true;
+    const std::wstring subkey =
+        L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Notifications\\"
+        L"Settings\\" +
+        acecode::utf8_to_wide(application_id);
+    DWORD value = 0;
+    if (read_dword(HKEY_CURRENT_USER, subkey.c_str(), L"Enabled", &value)) {
+        return value != 0;
+    }
+    // No per-app entry means the user never touched the setting.
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// WinToast backend
+// ---------------------------------------------------------------------------
+
+#ifdef ACECODE_HAS_WINTOAST
+
+bool g_wintoast_ready = false;
 std::wstring g_notification_logo_path;
 
 constexpr int kNotificationLogoResourceId = 101;
@@ -99,27 +207,25 @@ public:
 
     void toastFailed() const override {
         LOG_WARN("[notifications] WinToast reported delivery failure for " +
-                 payload_.id);
+                 payload_.id +
+                 "; switching to the self-drawn renderer for later toasts");
+        g_system_delivery_failed.store(true, std::memory_order_release);
     }
 
 private:
     NotifyPayload payload_;
 };
 
-} // namespace
-
-bool initialize(const NotificationInitOptions& options) {
-    std::lock_guard<std::mutex> lock(g_backend_mu);
-    if (g_initialized) return true;
-    if (options.application_id.empty()) {
-        LOG_WARN("[notifications] WinToast initialization skipped: empty AUMI");
+bool wintoast_compatible() {
+    try {
+        return WinToastLib::WinToast::isCompatible();
+    } catch (...) {
         return false;
     }
-    if (!WinToastLib::WinToast::isCompatible()) {
-        LOG_WARN("[notifications] WinToast is not compatible with this Windows version");
-        return false;
-    }
+}
 
+bool wintoast_initialize(const NotificationInitOptions& options) {
+    if (g_wintoast_ready) return true;
     try {
         WinToastLib::setDebugOutputEnabled(false);
         auto* toast = WinToastLib::WinToast::instance();
@@ -142,23 +248,19 @@ bool initialize(const NotificationInitOptions& options) {
         LOG_WARN("[notifications] WinToast initialization threw: " +
                  std::string(e.what()));
         return false;
+    } catch (...) {
+        LOG_WARN("[notifications] WinToast initialization threw an unknown "
+                 "exception");
+        return false;
     }
 
     g_notification_logo_path = materialize_notification_logo();
-    g_initialized = true;
-    notification_detail::publish_authorization_state({
-        NotificationAuthorizationStatus::Authorized, false, false});
-    LOG_INFO("[notifications] WinToast initialized" +
-             std::string(g_notification_logo_path.empty()
-                 ? " without app logo override"
-                 : " with ACECode app logo"));
+    g_wintoast_ready = true;
     return true;
 }
 
-bool show(const NotifyPayload& payload) {
-    std::lock_guard<std::mutex> lock(g_backend_mu);
-    if (!g_initialized) return false;
-
+bool wintoast_show(const NotifyPayload& payload) {
+    if (!g_wintoast_ready) return false;
     try {
         WinToastLib::WinToastTemplate toast(
             WinToastLib::WinToastTemplate::WinToastTemplateType::Text02);
@@ -192,21 +294,171 @@ bool show(const NotifyPayload& payload) {
     }
 }
 
+void wintoast_shutdown() {
+    if (!g_wintoast_ready) return;
+    g_wintoast_ready = false;
+    g_notification_logo_path.clear();
+    try {
+        WinToastLib::WinToast::instance()->clear();
+    } catch (...) {
+        LOG_WARN("[notifications] WinToast shutdown failed");
+    }
+}
+
+#else // !ACECODE_HAS_WINTOAST
+
+// MinGW/WinLibs toolchains ship without the WRL headers WinToast needs. The
+// self-drawn renderer only uses plain Win32 + GDI, so those builds still get
+// notifications instead of the old no-op stub.
+bool wintoast_compatible() { return false; }
+bool wintoast_initialize(const NotificationInitOptions&) { return false; }
+bool wintoast_show(const NotifyPayload&) { return false; }
+void wintoast_shutdown() {}
+
+#endif // ACECODE_HAS_WINTOAST
+
+// ---------------------------------------------------------------------------
+// Backend routing
+// ---------------------------------------------------------------------------
+
+bool start_custom_backend_locked() {
+    if (custom_toast::is_available()) return true;
+    custom_toast::InitOptions options;
+    options.app_name = g_app_name;
+    options.activation_window = g_activation_window;
+    return custom_toast::initialize(options);
+}
+
+// Applies `decision` and starts whatever backend it selected. Returns the
+// backend that is actually usable afterwards.
+NotificationBackendChoice adopt_decision_locked(
+    const NotificationBackendDecision& decision) {
+    if (decision.choice == NotificationBackendChoice::Custom &&
+        !start_custom_backend_locked()) {
+        LOG_WARN("[notifications] self-drawn renderer unavailable, no "
+                 "notifications will be shown");
+        return NotificationBackendChoice::None;
+    }
+    return decision.choice;
+}
+
+// Returns true when the backend changed, so the caller can publish the new
+// authorization state after releasing the backend mutex — the application
+// handler runs arbitrary code and must never be invoked under this lock.
+bool redecide_locked() {
+    g_signals.runtime_delivery_failed =
+        g_system_delivery_failed.load(std::memory_order_acquire);
+    const NotificationBackendDecision decision =
+        decide_notification_backend(g_preference, g_signals);
+    const NotificationBackendChoice adopted = adopt_decision_locked(decision);
+    if (adopted == g_choice) return false;
+    LOG_WARN(std::string("[notifications] switching backend to ") +
+             notification_backend_choice_name(adopted) + ": " +
+             decision.reason);
+    g_choice = adopted;
+    return true;
+}
+
+} // namespace
+
+bool initialize(const NotificationInitOptions& options) {
+    std::lock_guard<std::mutex> lock(g_backend_mu);
+    if (g_initialized) return true;
+
+    g_preference = parse_notification_backend_preference(options.backend);
+    g_app_name = options.app_name.empty() ? std::string("ACECode")
+                                          : options.app_name;
+    g_activation_window = options.activation_window;
+    g_system_delivery_failed.store(false, std::memory_order_release);
+
+    g_signals = SystemToastSignals{};
+    g_signals.platform_supported =
+        !options.application_id.empty() && wintoast_compatible();
+    g_signals.policy_disabled = toast_policy_disabled();
+    g_signals.toasts_enabled_globally = toasts_enabled_globally();
+    g_signals.app_toasts_enabled = app_toasts_enabled(options.application_id);
+
+    NotificationBackendDecision decision =
+        decide_notification_backend(g_preference, g_signals);
+    if (decision.choice == NotificationBackendChoice::System &&
+        !wintoast_initialize(options)) {
+        // Initialization failure is a hard signal that the OS path is unusable
+        // on this machine; re-run the decision without it.
+        g_signals.platform_supported = false;
+        decision = decide_notification_backend(g_preference, g_signals);
+    }
+
+    g_choice = adopt_decision_locked(decision);
+    g_initialized = g_choice != NotificationBackendChoice::None;
+
+    LOG_INFO(std::string("[notifications] backend=") +
+             notification_backend_choice_name(g_choice) + " (preference=" +
+             std::string(notification_backend_preference_value(g_preference)) +
+             ", " + decision.reason + ")");
+
+    if (!g_initialized) {
+        wintoast_shutdown();
+        notification_detail::publish_authorization_state({
+            NotificationAuthorizationStatus::Unavailable, false, false});
+        return false;
+    }
+
+    notification_detail::publish_authorization_state({
+        NotificationAuthorizationStatus::Authorized, false, false});
+    return true;
+}
+
+bool show(const NotifyPayload& payload) {
+    bool shown = false;
+    bool backend_changed = false;
+    NotificationBackendChoice choice = NotificationBackendChoice::None;
+    {
+        std::lock_guard<std::mutex> lock(g_backend_mu);
+        if (!g_initialized) return false;
+
+        if (g_choice == NotificationBackendChoice::System &&
+            g_system_delivery_failed.load(std::memory_order_acquire)) {
+            backend_changed = redecide_locked();
+        }
+
+        if (g_choice == NotificationBackendChoice::System) {
+            shown = wintoast_show(payload);
+            if (!shown) {
+                g_system_delivery_failed.store(true, std::memory_order_release);
+                backend_changed = redecide_locked() || backend_changed;
+            }
+        }
+
+        if (!shown && g_choice == NotificationBackendChoice::Custom) {
+            shown = custom_toast::show(payload);
+        }
+        choice = g_choice;
+    }
+
+    if (backend_changed) {
+        notification_detail::publish_authorization_state({
+            choice == NotificationBackendChoice::None
+                ? NotificationAuthorizationStatus::Unavailable
+                : NotificationAuthorizationStatus::Authorized,
+            false, false});
+    }
+    return shown;
+}
+
 void shutdown() {
     bool was_initialized = false;
     {
         std::lock_guard<std::mutex> lock(g_backend_mu);
         was_initialized = g_initialized;
         g_initialized = false;
-        g_notification_logo_path.clear();
+        g_choice = NotificationBackendChoice::None;
+        g_activation_window = nullptr;
+        g_system_delivery_failed.store(false, std::memory_order_release);
+        if (was_initialized) wintoast_shutdown();
     }
-    if (was_initialized) {
-        try {
-            WinToastLib::WinToast::instance()->clear();
-        } catch (...) {
-            LOG_WARN("[notifications] WinToast shutdown failed");
-        }
-    }
+    // Outside the lock: the renderer joins its own thread, and a click handler
+    // running there can re-enter this backend.
+    if (was_initialized) custom_toast::shutdown();
 }
 
 bool refresh_authorization() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2876,8 +2876,9 @@ static void shutdown_after_tui_loop(TuiState& state,
                                     SessionManager& session_manager,
                                     const AppConfig& config) {
 #ifdef _WIN32
-    // Clear WinToast handlers before any TUI/session objects captured by the
-    // activation callback begin teardown.
+    // Clear notification handlers (and stop the self-drawn toast thread) before
+    // any TUI/session objects captured by the activation callback begin
+    // teardown.
     acecode::desktop::shutdown_notifications();
 #endif
     g_active_screen.store(nullptr, std::memory_order_release);
@@ -5598,8 +5599,10 @@ static int run_interactive_app(const InteractiveCliOptions& cli,
     CommandRegistry cmd_registry;
     register_slash_commands(cmd_registry, skill_registry, config, working_dir);
 
-    // Windows TUI WinToast setup. Keep WinToast calls and session mutations on
-    // the FTXUI thread: activation callbacks only enqueue a main-loop task.
+    // Windows TUI notification setup. The backend (OS toast or the self-drawn
+    // renderer) is picked inside init_notifications; either way session
+    // mutations stay on the FTXUI thread because activation callbacks only
+    // enqueue a main-loop task.
     void* tui_notification_window = nullptr;
     bool tui_notifications_ready = false;
 #ifdef _WIN32
@@ -5611,6 +5614,7 @@ static int run_interactive_app(const InteractiveCliOptions& cli,
         notification_options.app_name = "ACECode TUI";
         notification_options.application_id = "ACECode.ACECode.TUI.1";
         notification_options.activation_window = tui_notification_window;
+        notification_options.backend = config.desktop.notifications.backend;
         tui_notifications_ready =
             acecode::desktop::init_notifications(notification_options);
         if (tui_notifications_ready) {

--- a/src/web/routes/routes_misc.cpp
+++ b/src/web/routes/routes_misc.cpp
@@ -34,6 +34,7 @@ json desktop_notifications_to_json(const DesktopNotificationsConfig& config) {
         {"on_question", config.on_question},
         {"on_completion", config.on_completion},
         {"suppress_when_focused", config.suppress_when_focused},
+        {"backend", config.backend},
     };
 }
 

--- a/tests/config/config_desktop_notifications_test.cpp
+++ b/tests/config/config_desktop_notifications_test.cpp
@@ -2,10 +2,11 @@
 // 设计参见 openspec/changes/add-windows-wintoast-completion-notifications。
 //
 // 验收点:
-//   - DesktopNotificationsConfig 五个字段默认全 true
+//   - DesktopNotificationsConfig 五个 bool 默认全 true,backend 默认 "auto"
 //   - desktop / desktop.notifications 段完全缺失 → 默认值,无 warning
 //   - 部分字段缺失 → 仅缺的字段走默认,提供的字段被读入
 //   - 字段类型错误(应该 bool 给了 string)→ 该字段保留默认 + 整段 warning
+//   - backend 只接受 auto|system|custom,其它值(含非法字符串)保留默认
 //   - desktop 整段非对象 / desktop.notifications 非对象 → 默认值 + warning
 //
 // 与 config_tui_test 风格一致:复刻 load_config 的解析分支,不依赖真实 config.json,
@@ -53,6 +54,12 @@ int apply_desktop_section(const nlohmann::json& j, DesktopNotificationsConfig& o
     if (nj.contains("suppress_when_focused") && nj["suppress_when_focused"].is_boolean()) {
         out.suppress_when_focused = nj["suppress_when_focused"].get<bool>();
     }
+    if (nj.contains("backend") && nj["backend"].is_string()) {
+        const std::string backend = nj["backend"].get<std::string>();
+        if (backend == "auto" || backend == "system" || backend == "custom") {
+            out.backend = backend;
+        }
+    }
     return warnings;
 }
 
@@ -66,6 +73,7 @@ TEST(ConfigDesktopNotificationsDefaults, StructDefault) {
     EXPECT_TRUE(n.on_question);
     EXPECT_TRUE(n.on_completion);
     EXPECT_TRUE(n.suppress_when_focused);
+    EXPECT_EQ(n.backend, "auto");
 }
 
 // 场景:AppConfig 中默认包含 desktop.notifications 且默认全 true
@@ -76,6 +84,7 @@ TEST(ConfigDesktopNotificationsDefaults, NestedInAppConfig) {
     EXPECT_TRUE(cfg.desktop.notifications.on_question);
     EXPECT_TRUE(cfg.desktop.notifications.on_completion);
     EXPECT_TRUE(cfg.desktop.notifications.suppress_when_focused);
+    EXPECT_EQ(cfg.desktop.notifications.backend, "auto");
 }
 
 // 场景:config.json 完全没有 desktop 段 → 默认值,无警告
@@ -168,4 +177,33 @@ TEST(ConfigDesktopNotificationsLoader, NotificationsBlockWrongTypeWarns) {
     nlohmann::json j = {{"desktop", {{"notifications", "should be object"}}}};
     EXPECT_EQ(apply_desktop_section(j, n), 1);
     EXPECT_TRUE(n.enabled);
+}
+
+// 场景:backend 显式给合法值 → 读入
+TEST(ConfigDesktopNotificationsLoader, BackendAcceptsKnownValues) {
+    for (const char* value : {"auto", "system", "custom"}) {
+        DesktopNotificationsConfig n;
+        nlohmann::json j = {
+            {"desktop", {{"notifications", {{"backend", value}}}}}
+        };
+        EXPECT_EQ(apply_desktop_section(j, n), 0);
+        EXPECT_EQ(n.backend, value);
+    }
+}
+
+// 场景:backend 给了未知字符串或非字符串 → 静默保持默认 "auto"
+TEST(ConfigDesktopNotificationsLoader, BackendRejectsUnknownValue) {
+    DesktopNotificationsConfig n;
+    nlohmann::json j = {
+        {"desktop", {{"notifications", {{"backend", "wintoast"}}}}}
+    };
+    EXPECT_EQ(apply_desktop_section(j, n), 0);
+    EXPECT_EQ(n.backend, "auto");
+
+    DesktopNotificationsConfig m;
+    nlohmann::json k = {
+        {"desktop", {{"notifications", {{"backend", 42}}}}}
+    };
+    EXPECT_EQ(apply_desktop_section(k, m), 0);
+    EXPECT_EQ(m.backend, "auto");
 }

--- a/tests/desktop/custom_toast_layout_test.cpp
+++ b/tests/desktop/custom_toast_layout_test.cpp
@@ -1,0 +1,142 @@
+// 自绘弹框的纯几何/缓动逻辑测试(可移植)。
+//
+// Win32 渲染部分(层窗口 + GDI + per-pixel alpha)只能在 Windows 实机验证,
+// 但栈布局、屏幕锚定、DPI 缩放和三条缓动曲线都是纯算术,在这里锁住。
+
+#include <gtest/gtest.h>
+
+#include "desktop/custom_toast.hpp"
+
+#include <vector>
+
+using namespace acecode::desktop::custom_toast;
+
+TEST(CustomToastScaling, IdentityAtBaseDpi) {
+    EXPECT_EQ(scale_for_dpi(100, 96), 100);
+}
+
+TEST(CustomToastScaling, ScalesUpAndDown) {
+    EXPECT_EQ(scale_for_dpi(100, 192), 200);
+    EXPECT_EQ(scale_for_dpi(100, 144), 150);
+    EXPECT_EQ(scale_for_dpi(100, 48), 50);
+}
+
+TEST(CustomToastScaling, ZeroDpiFallsBackToBase) {
+    EXPECT_EQ(scale_for_dpi(37, 0), 37);
+}
+
+TEST(CustomToastEasing, EaseInStartsAtZeroAndEndsAtOne) {
+    EXPECT_FLOAT_EQ(ease_in_position(0, 500), 0.0f);
+    EXPECT_FLOAT_EQ(ease_in_position(500, 500), 1.0f);
+    EXPECT_FLOAT_EQ(ease_in_position(9999, 500), 1.0f);
+}
+
+TEST(CustomToastEasing, EaseInDecelerates) {
+    // 减速曲线:前半程走过的距离必须超过一半。
+    EXPECT_GT(ease_in_position(250, 500), 0.5f);
+    float previous = -1.0f;
+    for (std::uint32_t t = 0; t <= 500; t += 25) {
+        const float value = ease_in_position(t, 500);
+        EXPECT_GE(value, previous);
+        previous = value;
+    }
+}
+
+TEST(CustomToastEasing, EaseOutAcceleratesAndEndsOpaque) {
+    EXPECT_FLOAT_EQ(ease_out_position(0, 160), 0.0f);
+    EXPECT_FLOAT_EQ(ease_out_position(160, 160), 1.0f);
+    // 加速曲线:前半程走过的距离小于一半。
+    EXPECT_LT(ease_out_position(80, 160), 0.5f);
+}
+
+TEST(CustomToastEasing, ZeroDurationIsAlreadyDone) {
+    EXPECT_FLOAT_EQ(ease_in_position(0, 0), 1.0f);
+    EXPECT_FLOAT_EQ(ease_out_position(0, 0), 1.0f);
+    EXPECT_FLOAT_EQ(stack_collapse_position(0, 0), 1.0f);
+}
+
+TEST(CustomToastEasing, StackCollapseMatchesEaseInCurve) {
+    for (std::uint32_t t = 0; t <= 400; t += 50) {
+        EXPECT_FLOAT_EQ(stack_collapse_position(t, 400),
+                        ease_in_position(t, 400));
+    }
+}
+
+TEST(CustomToastDismissal, ClampsAbsurdSystemValues) {
+    EXPECT_EQ(clamp_auto_dismiss_seconds(0), 6u);
+    EXPECT_EQ(clamp_auto_dismiss_seconds(5), 6u);
+    EXPECT_EQ(clamp_auto_dismiss_seconds(7), 7u);
+    EXPECT_EQ(clamp_auto_dismiss_seconds(30), 30u);
+    EXPECT_EQ(clamp_auto_dismiss_seconds(3600), 30u);
+}
+
+TEST(CustomToastPlacement, AnchorsToBottomRightOfWorkArea) {
+    const ToastRect work_area{0, 0, 1920, 1040};
+    const ToastPlacement placement =
+        compute_toast_placement(work_area, 16, 16, 368, 96, 0, 1.0f);
+    EXPECT_EQ(placement.width, 368);
+    EXPECT_EQ(placement.height, 96);
+    EXPECT_EQ(placement.x, 1920 - 16 - 368);
+    EXPECT_EQ(placement.y, 1040 - 16 - 96);
+}
+
+TEST(CustomToastPlacement, RespectsWorkAreaOriginOnSecondaryMonitors) {
+    // 副屏工作区不是从 0 开始的;锚点必须跟着屏幕走。
+    const ToastRect work_area{1920, 0, 3840, 1080};
+    const ToastPlacement placement =
+        compute_toast_placement(work_area, 16, 16, 368, 96, 0, 1.0f);
+    EXPECT_EQ(placement.x, 3840 - 16 - 368);
+    EXPECT_EQ(placement.y, 1080 - 16 - 96);
+}
+
+TEST(CustomToastPlacement, StacksUpwardByVerticalOffset) {
+    const ToastRect work_area{0, 0, 1920, 1040};
+    const ToastPlacement lower =
+        compute_toast_placement(work_area, 16, 16, 368, 96, 0, 1.0f);
+    const ToastPlacement upper =
+        compute_toast_placement(work_area, 16, 16, 368, 96, 108, 1.0f);
+    EXPECT_EQ(upper.y, lower.y - 108);
+    EXPECT_EQ(upper.x, lower.x);
+}
+
+TEST(CustomToastPlacement, EaseInKeepsTheRightEdgePinned) {
+    const ToastRect work_area{0, 0, 1920, 1040};
+    const ToastPlacement half =
+        compute_toast_placement(work_area, 16, 16, 368, 96, 0, 0.5f);
+    EXPECT_EQ(half.width, 184);
+    // 右边缘不动:x + width 恒等于 work_area.right - margin。
+    EXPECT_EQ(half.x + half.width, 1920 - 16);
+}
+
+TEST(CustomToastPlacement, EaseInClampsOutOfRangeProgress) {
+    const ToastRect work_area{0, 0, 1920, 1040};
+    EXPECT_EQ(compute_toast_placement(work_area, 16, 16, 368, 96, 0, -1.0f).width,
+              0);
+    EXPECT_EQ(compute_toast_placement(work_area, 16, 16, 368, 96, 0, 4.0f).width,
+              368);
+}
+
+TEST(CustomToastStack, OffsetsAccumulateHeightsAndMargins) {
+    const std::vector<int> heights{96, 120, 96};
+    const std::vector<int> offsets = compute_stack_offsets(heights, 12);
+    ASSERT_EQ(offsets.size(), 3u);
+    EXPECT_EQ(offsets[0], 0);
+    EXPECT_EQ(offsets[1], 96 + 12);
+    EXPECT_EQ(offsets[2], 96 + 12 + 120 + 12);
+}
+
+TEST(CustomToastStack, EmptyStackHasNoOffsets) {
+    EXPECT_TRUE(compute_stack_offsets({}, 12).empty());
+}
+
+TEST(CustomToastBody, FitsWholeLinesUpToTheCap) {
+    EXPECT_EQ(fit_body_lines(60, 20, 3), 3);
+    EXPECT_EQ(fit_body_lines(41, 20, 3), 2);
+    EXPECT_EQ(fit_body_lines(19, 20, 3), 0);
+    EXPECT_EQ(fit_body_lines(1000, 20, 3), 3);
+}
+
+TEST(CustomToastBody, DegenerateInputsReturnZero) {
+    EXPECT_EQ(fit_body_lines(100, 0, 3), 0);
+    EXPECT_EQ(fit_body_lines(100, 20, 0), 0);
+}

--- a/tests/desktop/notification_backend_policy_test.cpp
+++ b/tests/desktop/notification_backend_policy_test.cpp
@@ -1,0 +1,159 @@
+// Windows 弹框后端选择策略的可移植测试。
+//
+// 背景:WinToast 在部分 Win10 机器上 initialize/showToast 全部返回成功,弹框
+// 却永远不出现 —— AUMID 快捷方式缺失、通知被系统或组策略关掉、被"优化"工具
+// 禁用通知平台。这些都读不出错误码,只能靠注册表信号提前判定,改走自绘渲染。
+// 这里覆盖判定表本身;注册表探测与 GDI 渲染在 Windows 端实机验证。
+
+#include <gtest/gtest.h>
+
+#include "desktop/notification_backend_policy.hpp"
+
+using namespace acecode::desktop;
+
+namespace {
+
+SystemToastSignals healthy_signals() {
+    SystemToastSignals signals;
+    signals.platform_supported = true;
+    return signals;
+}
+
+} // namespace
+
+TEST(NotificationBackendPreference, ParsesKnownValues) {
+    EXPECT_EQ(parse_notification_backend_preference("auto"),
+              NotificationBackendPreference::Auto);
+    EXPECT_EQ(parse_notification_backend_preference("system"),
+              NotificationBackendPreference::System);
+    EXPECT_EQ(parse_notification_backend_preference("custom"),
+              NotificationBackendPreference::Custom);
+}
+
+TEST(NotificationBackendPreference, IsCaseAndWhitespaceInsensitive) {
+    EXPECT_EQ(parse_notification_backend_preference("  Custom "),
+              NotificationBackendPreference::Custom);
+    EXPECT_EQ(parse_notification_backend_preference("SYSTEM"),
+              NotificationBackendPreference::System);
+}
+
+TEST(NotificationBackendPreference, AcceptsAliases) {
+    EXPECT_EQ(parse_notification_backend_preference("wintoast"),
+              NotificationBackendPreference::System);
+    EXPECT_EQ(parse_notification_backend_preference("builtin"),
+              NotificationBackendPreference::Custom);
+}
+
+TEST(NotificationBackendPreference, UnknownValueFallsBack) {
+    EXPECT_EQ(parse_notification_backend_preference(""),
+              NotificationBackendPreference::Auto);
+    EXPECT_EQ(parse_notification_backend_preference(
+                  "nope", NotificationBackendPreference::Custom),
+              NotificationBackendPreference::Custom);
+}
+
+TEST(NotificationBackendPreference, RoundTripsThroughConfigValue) {
+    for (auto preference : {NotificationBackendPreference::Auto,
+                            NotificationBackendPreference::System,
+                            NotificationBackendPreference::Custom}) {
+        EXPECT_EQ(parse_notification_backend_preference(
+                      notification_backend_preference_value(preference)),
+                  preference);
+    }
+}
+
+TEST(NotificationBackendDecision, AutoPrefersSystemWhenNothingSuppressesIt) {
+    const auto decision = decide_notification_backend(
+        NotificationBackendPreference::Auto, healthy_signals());
+    EXPECT_EQ(decision.choice, NotificationBackendChoice::System);
+    EXPECT_FALSE(decision.reason.empty());
+}
+
+TEST(NotificationBackendDecision, AutoFallsBackWhenPlatformUnsupported) {
+    SystemToastSignals signals = healthy_signals();
+    signals.platform_supported = false;
+    EXPECT_EQ(decide_notification_backend(NotificationBackendPreference::Auto,
+                                          signals)
+                  .choice,
+              NotificationBackendChoice::Custom);
+}
+
+TEST(NotificationBackendDecision, AutoFallsBackWhenToastsDisabledSystemWide) {
+    SystemToastSignals signals = healthy_signals();
+    signals.toasts_enabled_globally = false;
+    EXPECT_EQ(decide_notification_backend(NotificationBackendPreference::Auto,
+                                          signals)
+                  .choice,
+              NotificationBackendChoice::Custom);
+}
+
+TEST(NotificationBackendDecision, AutoFallsBackWhenAppToastsDisabled) {
+    SystemToastSignals signals = healthy_signals();
+    signals.app_toasts_enabled = false;
+    EXPECT_EQ(decide_notification_backend(NotificationBackendPreference::Auto,
+                                          signals)
+                  .choice,
+              NotificationBackendChoice::Custom);
+}
+
+TEST(NotificationBackendDecision, AutoFallsBackOnGroupPolicy) {
+    SystemToastSignals signals = healthy_signals();
+    signals.policy_disabled = true;
+    EXPECT_EQ(decide_notification_backend(NotificationBackendPreference::Auto,
+                                          signals)
+                  .choice,
+              NotificationBackendChoice::Custom);
+}
+
+TEST(NotificationBackendDecision, AutoFallsBackAfterRuntimeDeliveryFailure) {
+    SystemToastSignals signals = healthy_signals();
+    signals.runtime_delivery_failed = true;
+    EXPECT_EQ(decide_notification_backend(NotificationBackendPreference::Auto,
+                                          signals)
+                  .choice,
+              NotificationBackendChoice::Custom);
+}
+
+TEST(NotificationBackendDecision, CustomIgnoresEverySystemSignal) {
+    SystemToastSignals signals = healthy_signals();
+    EXPECT_EQ(decide_notification_backend(NotificationBackendPreference::Custom,
+                                          signals)
+                  .choice,
+              NotificationBackendChoice::Custom);
+
+    signals.platform_supported = false;
+    signals.policy_disabled = true;
+    EXPECT_EQ(decide_notification_backend(NotificationBackendPreference::Custom,
+                                          signals)
+                  .choice,
+              NotificationBackendChoice::Custom);
+}
+
+TEST(NotificationBackendDecision, SystemIsNeverSilentlyReplacedByCustom) {
+    // 用户显式要 OS 通知(想要通知中心归档)时不擅自换成自绘窗口。
+    SystemToastSignals signals = healthy_signals();
+    signals.platform_supported = false;
+    const auto decision = decide_notification_backend(
+        NotificationBackendPreference::System, signals);
+    EXPECT_EQ(decision.choice, NotificationBackendChoice::None);
+}
+
+TEST(NotificationBackendDecision, SystemIgnoresSuppressionSignals) {
+    // 注册表信号只是启发式;显式选 system 时仍然尝试投递。
+    SystemToastSignals signals = healthy_signals();
+    signals.toasts_enabled_globally = false;
+    signals.app_toasts_enabled = false;
+    EXPECT_EQ(decide_notification_backend(NotificationBackendPreference::System,
+                                          signals)
+                  .choice,
+              NotificationBackendChoice::System);
+}
+
+TEST(NotificationBackendChoiceName, CoversEveryChoice) {
+    EXPECT_STREQ(notification_backend_choice_name(
+                     NotificationBackendChoice::None), "none");
+    EXPECT_STREQ(notification_backend_choice_name(
+                     NotificationBackendChoice::System), "system");
+    EXPECT_STREQ(notification_backend_choice_name(
+                     NotificationBackendChoice::Custom), "custom");
+}

--- a/tests/desktop/notifications_native_test.cpp
+++ b/tests/desktop/notifications_native_test.cpp
@@ -185,4 +185,33 @@ TEST(NativeNotifications, OptInDeliversWindowsToastAndActivatesWindow) {
 #endif
 }
 
+// 手动冒烟:在"WinToast 装了也不弹"的那类 Win10 机器上直接验证自绘弹框。
+// 强制 backend=custom 绕开系统 toast 通路,弹框应出现在工作区右下角。
+TEST(NativeNotifications, OptInDeliversSelfDrawnToast) {
+#ifdef _WIN32
+    const char* enabled = std::getenv("ACECODE_RUN_NOTIFICATION_SMOKE");
+    if (!enabled || std::string(enabled) != "1") {
+        GTEST_SKIP() << "set ACECODE_RUN_NOTIFICATION_SMOKE=1 for the Windows runtime smoke";
+    }
+
+    acecode::desktop::shutdown_notifications();
+    acecode::desktop::NotificationInitOptions options;
+    options.app_name = "ACECode Desktop";
+    options.application_id = "ACECode.ACECode.Desktop.1";
+    options.activation_window =
+        acecode::desktop::capture_tui_notification_window();
+    options.backend = "custom";
+    ASSERT_TRUE(acecode::desktop::init_notifications(options));
+
+    EXPECT_TRUE(acecode::desktop::show_notification(
+        sample_payload("completion-custom-smoke", "session-custom-smoke")));
+
+    // 渲染线程是异步的:留出够看到淡入动画的时间再拆掉。
+    std::this_thread::sleep_for(std::chrono::milliseconds(2500));
+    acecode::desktop::shutdown_notifications();
+#else
+    GTEST_SKIP() << "the self-drawn toast renderer is Windows-only";
+#endif
+}
+
 } // namespace

--- a/tests/desktop/notifications_test.cpp
+++ b/tests/desktop/notifications_test.cpp
@@ -1,7 +1,9 @@
 // notifications.{hpp,cpp} 公共生命周期契约的可移植测试。
 //
-// Windows 实现使用 WinToast，macOS Desktop 使用 UserNotifications，其他平台
-// 保留 no-op 桩。这里覆盖不依赖真实通知中心的默认值、失败降级与重复清理行为。
+// Windows 实现在系统 toast(WinToast)与自绘弹框之间按策略二选一，macOS Desktop
+// 使用 UserNotifications，其他平台保留 no-op 桩。后端选择判定表在
+// notification_backend_policy_test.cpp。
+// 这里覆盖不依赖真实通知中心的默认值、失败降级与重复清理行为。
 // Payload 解析、Unicode 截断和独立 activation 路由见
 // notifications_native_test.cpp。
 
@@ -38,9 +40,13 @@ TEST(DesktopNotificationsPayload, AssignAllFieldsCopiesCleanly) {
 TEST(DesktopNotificationsLifecycle, InitWithoutPlatformIdentityIsSafe) {
     shutdown_notifications();
     NotificationInitOptions options;
-#ifdef __APPLE__
-    // A command-line test runner may or may not be wrapped in a bundle by the
-    // generator. Either result is valid; lifecycle safety is the contract.
+#if defined(__APPLE__) || defined(_WIN32)
+    // macOS: a command-line test runner may or may not be wrapped in a bundle
+    // by the generator.
+    // Windows: a missing AppUserModelID no longer means "no notifications" —
+    // the self-drawn renderer covers that case — but it still needs a usable
+    // window station, which a headless runner may not have.
+    // Either result is valid; lifecycle safety is the contract.
     const bool initialized = init_notifications(options);
     if (initialized) shutdown_notifications();
 #else
@@ -52,6 +58,22 @@ TEST(DesktopNotificationsLifecycle, InitWithoutPlatformIdentityIsSafe) {
     EXPECT_NO_THROW(shutdown_notifications());
 #endif
 }
+
+#ifdef _WIN32
+TEST(DesktopNotificationsLifecycle, SystemBackendIsNotSilentlyReplaced) {
+    // backend="system" 是显式选择:没有 AUMID 就没有系统 toast,此时不擅自
+    // 换成自绘窗口,而是老老实实报告初始化失败。
+    shutdown_notifications();
+    NotificationInitOptions options;
+    options.backend = "system";
+    EXPECT_FALSE(init_notifications(options));
+    NotifyPayload p;
+    p.title = "x";
+    p.body = "y";
+    EXPECT_FALSE(show_notification(p));
+    EXPECT_NO_THROW(shutdown_notifications());
+}
+#endif
 
 TEST(DesktopNotificationsLifecycle, RepeatedShutdownIsSafe) {
     EXPECT_NO_THROW(shutdown_notifications());


### PR DESCRIPTION
WinToast reports success on plenty of Windows 10 machines while the OS
silently drops the toast: the Start Menu shortcut carrying the AUMID was
never created, notifications are off for the app or system-wide, group
policy forbids them, or a "debloat" tool disabled the notification
platform. None of that shows up in a return value, so no amount of error
handling around WinToast can catch it.

Add a self-drawn renderer modeled on Electron's win32_desktop_notifications
(MIT, see LICENSES/MIT-electron.txt): a hidden controller window driving a
15ms animation timer over a bottom-right stack of layered, non-activating
popups drawn with GDI and pushed through UpdateLayeredWindow, with
slide-in, alpha fade-out and stack-collapse animations, hover-to-hold,
click-to-open and a close control.

Two departures from Electron. It runs on its own thread with its own
message loop, because the FTXUI terminal binary has no Win32 message pump
at all and has to share this API with the desktop shell. And it paints a
rounded card with per-pixel alpha instead of an opaque rectangle, which
means rewriting the alpha plane after every draw since GDI text output
leaves alpha undefined.

Route between the two backends with desktop.notifications.backend
(auto|system|custom, default auto). Under auto, probe the registry keys
that suppress toasts silently and pick the self-drawn path when any of
them is hostile; degrade stickily when a delivery fails, including via
WinToast's async failure callback. backend=system is honored verbatim —
an explicit request for Action Center integration is never substituted.

The Windows backend now compiles in every Windows build, so MinGW/WinLibs
toolchains get working notifications instead of the no-op stub.

Verified: portable logic compiles and passes under -std=c++17 -Wall
-Wextra; both Windows sources cross-compile warning-clean with and
without ACECODE_HAS_WINTOAST and link against gdi32/msimg32/winmm. The
rendering itself needs a Windows host and is untested here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BuzJ2Dfr3mhJkKUbXPDtxN