### PR TITLE
Release v0.8.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if(CMAKE_HOST_WIN32 AND DEFINED CMAKE_TOOLCHAIN_FILE AND CMAKE_TOOLCHAIN_FILE MA
     set(VCPKG_TARGET_TRIPLET "x64-windows-static" CACHE STRING "Vcpkg target triplet" FORCE)
 endif()
 
-project(acecode VERSION 0.8.7 LANGUAGES C CXX)
+project(acecode VERSION 0.8.8 LANGUAGES C CXX)
 
 option(ACECODE_TUI_INPUT_TRACE "Enable verbose TUI input event trace logging." OFF)
 

--- a/docs/macos-release.md
+++ b/docs/macos-release.md
@@ -121,8 +121,8 @@ The version in `CMakeLists.txt` is authoritative. The tag must match it exactly:
 ```bash
 git switch master
 git pull --ff-only
-git tag -a v0.8.7 -m "ACECode v0.8.7"
-git push origin v0.8.7
+git tag -a v0.8.8 -m "ACECode v0.8.8"
+git push origin v0.8.8
 ```
 
 The tag starts the full package workflow. After every platform build succeeds,

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name":  "acecode",
-    "version-semver":  "0.8.7",
+    "version-semver":  "0.8.8",
     "dependencies":  [
                          "cpr",
                          "crow",


### PR DESCRIPTION
## What changed

- bump the authoritative CMake and vcpkg versions from 0.8.7 to 0.8.8
- update the macOS release documentation example to use the new tag

## Why

The existing `v0.8.7` tag and GitHub Release point to an older commit from before the signed, notarized macOS DMG pipeline was merged. A new patch version preserves that published history and gives the new installer pipeline a unique release tag.

## Impact

After this PR is merged, tagging `v0.8.8` will build all supported platforms, publish signed and notarized x64/arm64 DMGs, create the GitHub Release, and publish the npm packages at version 0.8.8.

## Verification

- `bash tests/scripts/macos_release_scripts_test.sh`
- parsed `.github/workflows/package.yml` successfully
- verified `CMakeLists.txt` and `vcpkg.json` both declare `0.8.8`
- verified the signed/notarized macOS package workflow on the preceding master commit: https://github.com/shaohaozhi286/acecode/actions/runs/31102107192
