### PR TITLE
Improve macOS DMG drag installation

### DIFF
--- a/assets/macos/acecode-dmg-background.svg
+++ b/assets/macos/acecode-dmg-background.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="720"
+  height="520"
+  viewBox="0 0 720 520"
+  fill="none"
+  role="img"
+  aria-labelledby="title description"
+>
+  <title id="title">ACECode DMG installation background</title>
+  <desc id="description">A branded left-to-right drag guide for installing ACECode for the current user.</desc>
+
+  <defs>
+    <linearGradient id="canvas" x1="45" y1="18" x2="674" y2="447" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F8FCFF"/>
+      <stop offset="0.52" stop-color="#EDF7FF"/>
+      <stop offset="1" stop-color="#DDEBFF"/>
+    </linearGradient>
+    <radialGradient id="glow-left" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(124 190) rotate(18) scale(264 210)">
+      <stop stop-color="#38D5F7" stop-opacity="0.22"/>
+      <stop offset="1" stop-color="#38D5F7" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glow-right" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(592 232) rotate(158) scale(244 210)">
+      <stop stop-color="#2563EB" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#2563EB" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="arrow" x1="287" y1="218" x2="433" y2="218" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#20BCE8"/>
+      <stop offset="1" stop-color="#2563EB"/>
+    </linearGradient>
+    <filter id="panel-shadow" x="-14%" y="-14%" width="128%" height="136%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="8" stdDeviation="12" flood-color="#194379" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+
+  <rect width="720" height="520" fill="url(#canvas)"/>
+  <rect width="720" height="520" fill="url(#glow-left)"/>
+  <rect width="720" height="520" fill="url(#glow-right)"/>
+  <path d="M0 468C116 432 206 439 302 474C412 515 562 510 720 450V520H0V468Z" fill="#2563EB" fill-opacity="0.055"/>
+
+  <text x="360" y="48" text-anchor="middle" fill="#0B2850" font-family="-apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif" font-size="25" font-weight="700">
+    Install ACECode · 安装 ACECode
+  </text>
+  <text x="360" y="78" text-anchor="middle" fill="#46627F" font-family="-apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif" font-size="14" font-weight="500">
+    Installs to ~/Applications · 当前用户安装 · No administrator password
+  </text>
+
+  <g filter="url(#panel-shadow)">
+    <rect x="74" y="113" width="192" height="225" rx="34" fill="white" fill-opacity="0.62" stroke="white" stroke-width="2"/>
+    <rect x="454" y="113" width="192" height="225" rx="34" fill="white" fill-opacity="0.72" stroke="#2B73E8" stroke-opacity="0.34" stroke-width="2" stroke-dasharray="8 8"/>
+  </g>
+
+  <text x="170" y="139" text-anchor="middle" fill="#3C5A78" font-family="-apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif" font-size="13" font-weight="600">
+    ACECode.app
+  </text>
+  <text x="550" y="139" text-anchor="middle" fill="#235AAE" font-family="-apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif" font-size="13" font-weight="700">
+    Drag here · 拖到这里
+  </text>
+
+  <path d="M292 218H421" stroke="url(#arrow)" stroke-width="11" stroke-linecap="round"/>
+  <path d="M398 190L430 218L398 246" stroke="#2563EB" stroke-width="11" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="292" cy="218" r="7" fill="#20BCE8"/>
+
+  <rect x="212" y="315" width="296" height="185" rx="24" fill="white" fill-opacity="0.52" stroke="#6F9BD6" stroke-opacity="0.22"/>
+</svg>

--- a/assets/macos/acecode-installer.svg
+++ b/assets/macos/acecode-installer.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="512"
+  height="512"
+  viewBox="0 0 512 512"
+  fill="none"
+  role="img"
+  aria-labelledby="title description"
+>
+  <title id="title">ACECode current-user installer icon</title>
+  <desc id="description">The ACECode app icon with a prominent download-to-tray badge.</desc>
+
+  <defs>
+    <linearGradient id="background" x1="70" y1="36" x2="446" y2="482" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#38D5F7"/>
+      <stop offset="0.38" stop-color="#1687DA"/>
+      <stop offset="0.72" stop-color="#2563EB"/>
+      <stop offset="1" stop-color="#082A52"/>
+    </linearGradient>
+    <radialGradient
+      id="highlight"
+      cx="0"
+      cy="0"
+      r="1"
+      gradientUnits="userSpaceOnUse"
+      gradientTransform="translate(108 70) rotate(44) scale(282 224)"
+    >
+      <stop stop-color="white" stop-opacity="0.44"/>
+      <stop offset="0.62" stop-color="#A5F3FC" stop-opacity="0.08"/>
+      <stop offset="1" stop-color="#A5F3FC" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="letter" x1="91" y1="124" x2="317" y2="391" gradientUnits="userSpaceOnUse">
+      <stop stop-color="white"/>
+      <stop offset="1" stop-color="#E0F2FE"/>
+    </linearGradient>
+    <linearGradient id="badge" x1="330" y1="324" x2="468" y2="467" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0F2C58"/>
+      <stop offset="1" stop-color="#06142E"/>
+    </linearGradient>
+    <filter id="tile-shadow" x="-10%" y="-8%" width="120%" height="132%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.32"/>
+    </filter>
+    <filter id="badge-shadow" x="-24%" y="-24%" width="148%" height="158%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="9" stdDeviation="9" flood-color="#020617" flood-opacity="0.42"/>
+    </filter>
+    <clipPath id="tile-clip">
+      <rect x="20" y="20" width="472" height="472" rx="112"/>
+    </clipPath>
+  </defs>
+
+  <g filter="url(#tile-shadow)">
+    <rect x="20" y="20" width="472" height="472" rx="112" fill="url(#background)"/>
+    <g clip-path="url(#tile-clip)">
+      <rect x="20" y="20" width="472" height="472" fill="url(#highlight)"/>
+      <path d="M20 386C126 326 223 326 310 363C378 392 438 391 492 357V492H20V386Z" fill="#020617" fill-opacity="0.12"/>
+    </g>
+    <rect x="21.5" y="21.5" width="469" height="469" rx="110.5" stroke="white" stroke-opacity="0.24" stroke-width="3"/>
+  </g>
+
+  <path
+    fill="url(#letter)"
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M68 386L161 137.5C165.7 125 175 119 189 119H208C222 119 231.3 125 236 137.5L329 386H263L244 328H151L132 386H68ZM172 267H223L197.8 190.4L172 267Z"
+  />
+  <path d="M340 191L424 244L340 297" stroke="#BFF7FF" stroke-width="36" stroke-linecap="square" stroke-linejoin="miter"/>
+
+  <g filter="url(#badge-shadow)">
+    <circle cx="398" cy="397" r="78" fill="url(#badge)" stroke="white" stroke-width="10"/>
+    <path d="M398 350V411" stroke="white" stroke-width="18" stroke-linecap="round"/>
+    <path d="M370 388L398 416L426 388" stroke="white" stroke-width="18" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M354 430V446H442V430" stroke="#77E8FA" stroke-width="16" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/cmake/acecode_desktop.cmake
+++ b/cmake/acecode_desktop.cmake
@@ -104,8 +104,28 @@ endif()
 
 if(APPLE)
     set(ACECODE_MACOS_ICON "${CMAKE_SOURCE_DIR}/assets/macos/acecode.icns")
+    set(ACECODE_MACOS_INSTALLER_ICON_SOURCE
+        "${CMAKE_SOURCE_DIR}/assets/macos/acecode-installer.svg")
+    set(ACECODE_MACOS_INSTALLER_ICON
+        "${CMAKE_BINARY_DIR}/generated/macos/acecode-installer.icns")
+    add_custom_command(
+        OUTPUT "${ACECODE_MACOS_INSTALLER_ICON}"
+        COMMAND /bin/bash
+            "${CMAKE_SOURCE_DIR}/scripts/macos_generate_icns.sh"
+            --source "${ACECODE_MACOS_INSTALLER_ICON_SOURCE}"
+            --output "${ACECODE_MACOS_INSTALLER_ICON}"
+        DEPENDS
+            "${ACECODE_MACOS_INSTALLER_ICON_SOURCE}"
+            "${CMAKE_SOURCE_DIR}/scripts/macos_generate_icns.sh"
+        COMMENT "Generating ACECode current-user installer icon"
+        VERBATIM
+    )
     target_sources(acecode-desktop PRIVATE "${ACECODE_MACOS_ICON}")
     set_source_files_properties("${ACECODE_MACOS_ICON}" PROPERTIES
+        MACOSX_PACKAGE_LOCATION "Resources"
+    )
+    set_source_files_properties("${ACECODE_MACOS_INSTALLER_ICON}" PROPERTIES
+        GENERATED TRUE
         MACOSX_PACKAGE_LOCATION "Resources"
     )
     set_target_properties(acecode-desktop PROPERTIES
@@ -141,7 +161,7 @@ if(APPLE)
         ${CMAKE_SOURCE_DIR}/src/macos_installer/main.mm
         ${CMAKE_SOURCE_DIR}/src/desktop/user_install_policy.cpp
         ${CMAKE_SOURCE_DIR}/src/desktop/user_install_policy.hpp
-        ${ACECODE_MACOS_ICON}
+        ${ACECODE_MACOS_INSTALLER_ICON}
     )
     target_include_directories(acecode-user-installer PRIVATE
         ${CMAKE_SOURCE_DIR}/src
@@ -153,7 +173,7 @@ if(APPLE)
     set_target_properties(acecode-user-installer PROPERTIES
         RUNTIME_OUTPUT_NAME "Install ACECode"
         MACOSX_BUNDLE_BUNDLE_NAME "Install ACECode"
-        MACOSX_BUNDLE_ICON_FILE "acecode.icns"
+        MACOSX_BUNDLE_ICON_FILE "acecode-installer.icns"
         MACOSX_BUNDLE_GUI_IDENTIFIER "dev.acecode.installer"
         MACOSX_BUNDLE_INFO_PLIST
             "${CMAKE_SOURCE_DIR}/cmake/macos/ACECodeUserInstallerInfo.plist.in"

--- a/cmake/macos/ACECodeUserInstallerInfo.plist.in
+++ b/cmake/macos/ACECodeUserInstallerInfo.plist.in
@@ -5,6 +5,25 @@
 <dict>
   <key>CFBundleDevelopmentRegion</key>
   <string>en</string>
+  <key>CFBundleDocumentTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>app</string>
+      </array>
+      <key>CFBundleTypeName</key>
+      <string>ACECode Application Bundle</string>
+      <key>CFBundleTypeRole</key>
+      <string>Viewer</string>
+      <key>LSHandlerRank</key>
+      <string>Alternate</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>com.apple.application-bundle</string>
+      </array>
+    </dict>
+  </array>
   <key>CFBundleDisplayName</key>
   <string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
   <key>CFBundleExecutable</key>

--- a/scripts/macos_create_dmg.sh
+++ b/scripts/macos_create_dmg.sh
@@ -6,11 +6,11 @@ usage() {
 Usage:
   scripts/macos_create_dmg.sh --app <ACECode.app> \
       --installer <Install ACECode.app> --output <ACECode.dmg> \
-      [--volume-name <name>] [--instructions <path>]
+      [--volume-name <name>] [--instructions <path>] [--background <path>]
 
-Creates a compressed read-only DMG containing ACECode.app, the current-user
-installer, and bilingual instructions. The image never contains a link to the
-system /Applications directory.
+Creates a styled compressed read-only DMG with ACECode.app on the left and the
+current-user installer on the right. The installer writes only to
+~/Applications; the image never contains a link to system /Applications.
 USAGE
 }
 
@@ -19,6 +19,7 @@ installer_path=""
 output_path=""
 volume_name="ACECode"
 instructions_path=""
+background_path=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -45,6 +46,11 @@ while [[ $# -gt 0 ]]; do
         --instructions)
             [[ $# -ge 2 && -n "${2:-}" ]] || { echo "Missing value for --instructions" >&2; exit 2; }
             instructions_path="$2"
+            shift 2
+            ;;
+        --background)
+            [[ $# -ge 2 && -n "${2:-}" ]] || { echo "Missing value for --background" >&2; exit 2; }
+            background_path="$2"
             shift 2
             ;;
         --help|-h)
@@ -88,8 +94,21 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [[ -z "$instructions_path" ]]; then
     instructions_path="$script_dir/../assets/macos/DMG_INSTALL.txt"
 fi
+if [[ -z "$background_path" ]]; then
+    background_path="$script_dir/../assets/macos/acecode-dmg-background.svg"
+fi
+volume_icon_path="$script_dir/../assets/macos/acecode.icns"
+
 if [[ ! -f "$instructions_path" ]]; then
     echo "Missing DMG instructions: $instructions_path" >&2
+    exit 1
+fi
+if [[ ! -f "$background_path" ]]; then
+    echo "Missing DMG background: $background_path" >&2
+    exit 1
+fi
+if [[ ! -f "$volume_icon_path" ]]; then
+    echo "Missing DMG volume icon: $volume_icon_path" >&2
     exit 1
 fi
 
@@ -99,7 +118,16 @@ mkdir -p "$output_parent"
 temporary_base="${TMPDIR:-/tmp}"
 temporary_base="${temporary_base%/}"
 temporary_root="$(mktemp -d "${temporary_base}/acecode-dmg.XXXXXX")"
+mount_root=""
+detach_target=""
+mounted=0
 cleanup() {
+    if [[ "${mounted:-0}" -eq 1 ]]; then
+        local cleanup_target="${mount_root:-${detach_target:-}}"
+        if [[ -n "$cleanup_target" ]]; then
+            /usr/bin/hdiutil detach "$cleanup_target" -force >/dev/null 2>&1 || true
+        fi
+    fi
     if [[ -n "${temporary_root:-}" && -d "$temporary_root" ]]; then
         rm -rf -- "$temporary_root"
     fi
@@ -107,23 +135,141 @@ cleanup() {
 trap cleanup EXIT
 
 staging_root="$temporary_root/root"
-mkdir -p "$staging_root"
+background_root="$staging_root/.background"
+mkdir -p "$staging_root" "$background_root"
 
 /usr/bin/ditto "$app_path" "$staging_root/ACECode.app"
 /usr/bin/ditto "$installer_path" "$staging_root/Install ACECode.app"
-/usr/bin/ditto "$instructions_path" "$staging_root/Install Instructions 安装说明.txt"
+/usr/bin/ditto "$instructions_path" "$staging_root/README 安装说明.txt"
+/usr/bin/sips -s format png "$background_path" \
+    --out "$background_root/ACECode-DMG.png" >/dev/null
 
 if [[ -e "$staging_root/Applications" || -L "$staging_root/Applications" ]]; then
     echo "Refusing to package a system /Applications link." >&2
     exit 1
 fi
 
+staging_size_kb="$(/usr/bin/du -sk "$staging_root" | /usr/bin/awk '{print $1}')"
+image_size_mb=$(( (staging_size_kb + 1023) / 1024 + 48 ))
+writable_dmg="$temporary_root/ACECode-layout.dmg"
+
 /usr/bin/hdiutil create \
     -volname "$volume_name" \
     -srcfolder "$staging_root" \
-    -format UDZO \
+    -size "${image_size_mb}m" \
+    -fs HFS+ \
+    -format UDRW \
     -ov \
-    "$output_path"
+    "$writable_dmg"
+
+attach_plist="$temporary_root/attach.plist"
+/usr/bin/hdiutil attach \
+    -readwrite \
+    -noverify \
+    -noautoopen \
+    -plist \
+    "$writable_dmg" >"$attach_plist"
+mounted=1
+
+for entity_index in 0 1 2 3 4 5 6 7; do
+    device_candidate="$(/usr/libexec/PlistBuddy \
+        -c "Print :system-entities:${entity_index}:dev-entry" \
+        "$attach_plist" 2>/dev/null || true)"
+    if [[ -n "$device_candidate" && -z "$detach_target" ]]; then
+        detach_target="$device_candidate"
+    fi
+    mount_candidate="$(/usr/libexec/PlistBuddy \
+        -c "Print :system-entities:${entity_index}:mount-point" \
+        "$attach_plist" 2>/dev/null || true)"
+    if [[ -n "$mount_candidate" ]]; then
+        mount_root="$mount_candidate"
+        if [[ -n "$device_candidate" ]]; then
+            detach_target="$device_candidate"
+        fi
+        break
+    fi
+done
+if [[ -z "$mount_root" || ! -d "$mount_root" ]]; then
+    echo "Could not determine the mounted DMG path." >&2
+    exit 1
+fi
+
+# Keep the background resources out of the visible Finder layout.
+/usr/bin/SetFile -a V "$mount_root/.background"
+
+apply_finder_layout() {
+    /usr/bin/osascript - "$mount_root" <<'APPLESCRIPT'
+on run argv
+    set expectedMountPath to item 1 of argv
+
+    tell application "Finder"
+        activate
+        set mountedFolder to folder (POSIX file expectedMountPath as alias)
+        tell mountedFolder
+            open
+            set dmgWindow to container window
+            set current view of dmgWindow to icon view
+            set toolbar visible of dmgWindow to false
+            set statusbar visible of dmgWindow to false
+            set pathbar visible of dmgWindow to false
+            set bounds of dmgWindow to {100, 100, 820, 620}
+
+            set iconOptions to icon view options of dmgWindow
+            set arrangement of iconOptions to not arranged
+            set icon size of iconOptions to 104
+            set text size of iconOptions to 13
+            set label position of iconOptions to bottom
+            set shows icon preview of iconOptions to false
+            set background picture of iconOptions to file ".background:ACECode-DMG.png"
+
+            set position of item "ACECode.app" of dmgWindow to {170, 220}
+            set position of item "Install ACECode.app" of dmgWindow to {550, 220}
+            set position of item "README 安装说明.txt" of dmgWindow to {360, 365}
+
+            update without registering applications
+            delay 2
+            close dmgWindow
+        end tell
+    end tell
+end run
+APPLESCRIPT
+}
+
+layout_log="$temporary_root/finder-layout.log"
+layout_applied=0
+for attempt in 1 2 3; do
+    if apply_finder_layout >"$layout_log" 2>&1; then
+        layout_applied=1
+        break
+    fi
+    echo "Finder layout attempt $attempt failed:" >&2
+    sed -n '1,120p' "$layout_log" >&2
+    sleep 2
+done
+if [[ "$layout_applied" -ne 1 ]]; then
+    echo "Could not apply the ACECode DMG Finder layout." >&2
+    exit 1
+fi
+
+# Finder may clean volume-icon metadata while first creating .DS_Store, so add
+# the custom mounted-volume icon only after the layout window has closed.
+/usr/bin/ditto "$volume_icon_path" "$mount_root/.VolumeIcon.icns"
+/usr/bin/SetFile -a V "$mount_root/.VolumeIcon.icns"
+/usr/bin/SetFile -a C "$mount_root"
+if [[ ! -f "$mount_root/.VolumeIcon.icns" ]]; then
+    echo "Could not add the DMG volume icon." >&2
+    exit 1
+fi
+
+/bin/sync
+/usr/bin/hdiutil detach "$mount_root"
+mounted=0
+
+/usr/bin/hdiutil convert "$writable_dmg" \
+    -format UDZO \
+    -imagekey zlib-level=9 \
+    -ov \
+    -o "$output_path"
 
 /usr/bin/hdiutil verify "$output_path"
 echo "Created $output_path"

--- a/scripts/macos_generate_icns.sh
+++ b/scripts/macos_generate_icns.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/macos_generate_icns.sh --source <icon.svg> --output <icon.icns>
+
+Renders an SVG at every macOS iconset size using sips, then creates an ICNS
+file using iconutil. This helper must run on macOS.
+USAGE
+}
+
+source_path=""
+output_path=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --source)
+            [[ $# -ge 2 && -n "${2:-}" ]] || { echo "Missing value for --source" >&2; exit 2; }
+            source_path="$2"
+            shift 2
+            ;;
+        --output)
+            [[ $# -ge 2 && -n "${2:-}" ]] || { echo "Missing value for --output" >&2; exit 2; }
+            output_path="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$source_path" || -z "$output_path" ]]; then
+    echo "--source and --output are required." >&2
+    usage >&2
+    exit 2
+fi
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "ICNS generation must run on macOS." >&2
+    exit 1
+fi
+if [[ ! -f "$source_path" ]]; then
+    echo "Missing icon source: $source_path" >&2
+    exit 1
+fi
+if [[ "$output_path" != *.icns ]]; then
+    echo "ICNS output must end in .icns: $output_path" >&2
+    exit 2
+fi
+
+output_parent="$(dirname "$output_path")"
+mkdir -p "$output_parent"
+
+temporary_base="${TMPDIR:-/tmp}"
+temporary_base="${temporary_base%/}"
+temporary_root="$(mktemp -d "${temporary_base}/acecode-icon.XXXXXX")"
+cleanup() {
+    if [[ -n "${temporary_root:-}" && -d "$temporary_root" ]]; then
+        rm -rf -- "$temporary_root"
+    fi
+}
+trap cleanup EXIT
+
+iconset_path="$temporary_root/acecode-installer.iconset"
+mkdir -p "$iconset_path"
+
+render_icon() {
+    local pixels="$1"
+    local filename="$2"
+    /usr/bin/sips -s format png -z "$pixels" "$pixels" \
+        "$source_path" --out "$iconset_path/$filename" >/dev/null
+}
+
+render_icon 16 icon_16x16.png
+render_icon 32 icon_16x16@2x.png
+render_icon 32 icon_32x32.png
+render_icon 64 icon_32x32@2x.png
+render_icon 128 icon_128x128.png
+render_icon 256 icon_128x128@2x.png
+render_icon 256 icon_256x256.png
+render_icon 512 icon_256x256@2x.png
+render_icon 512 icon_512x512.png
+render_icon 1024 icon_512x512@2x.png
+
+/usr/bin/iconutil -c icns "$iconset_path" -o "$output_path"
+echo "Created $output_path"

--- a/src/macos_installer/main.mm
+++ b/src/macos_installer/main.mm
@@ -19,6 +19,7 @@ void show_alert(NSAlertStyle style, NSString* message, NSString* detail) {
     [alert setInformativeText:detail ?: @""];
     [alert addButtonWithTitle:@"OK"];
     [alert runModal];
+    [alert release];
 }
 
 void show_error(NSString* detail) {
@@ -77,180 +78,295 @@ bool bundle_identifier_matches(NSURL* bundle_url) {
         isEqualToString:kAcecodeBundleIdentifier];
 }
 
+NSURL* expected_source_url() {
+    NSURL* installer_url = [[NSBundle mainBundle] bundleURL];
+    NSURL* image_root = [installer_url URLByDeletingLastPathComponent];
+    return [image_root URLByAppendingPathComponent:@"ACECode.app"
+                                       isDirectory:YES];
+}
+
+bool dropped_source_is_expected(NSURL* requested_url, NSURL* expected_url) {
+    if (!requested_url || !expected_url || ![requested_url isFileURL]) {
+        return false;
+    }
+    return filesystem_path(requested_url).lexically_normal() ==
+           filesystem_path(expected_url).lexically_normal();
+}
+
+int install_application(NSURL* source_url) {
+    NSFileManager* file_manager = [NSFileManager defaultManager];
+
+    BOOL source_is_directory = NO;
+    if (![file_manager fileExistsAtPath:[source_url path]
+                            isDirectory:&source_is_directory] ||
+        source_is_directory == NO) {
+        show_error(@"ACECode.app is missing beside the installer. Reopen the original DMG.\n\n安装器旁缺少 ACECode.app，请重新打开原始 DMG。");
+        return 1;
+    }
+
+    NSError* error = nil;
+    bool source_is_symlink = false;
+    if (!resource_flag(source_url, NSURLIsSymbolicLinkKey,
+                       &source_is_symlink, &error) || source_is_symlink) {
+        show_error(error_detail(
+            @"The ACECode payload is not a safe application bundle.\n\nACECode 安装文件不是安全的应用包。", error));
+        return 1;
+    }
+    if (!bundle_identifier_matches(source_url)) {
+        show_error(@"The ACECode payload has an unexpected bundle identifier.\n\nACECode 安装文件的 Bundle ID 不正确。");
+        return 1;
+    }
+
+    NSArray<NSRunningApplication*>* running =
+        [NSRunningApplication runningApplicationsWithBundleIdentifier:
+            kAcecodeBundleIdentifier];
+    if ([running count] != 0) {
+        show_error(@"Quit ACECode, then open this installer again.\n\n请先退出 ACECode，然后重新打开安装器。");
+        return 1;
+    }
+
+    const char* home_bytes = [NSHomeDirectory() fileSystemRepresentation];
+    if (!home_bytes) {
+        show_error(@"The current user's home directory is unavailable.\n\n无法读取当前用户的主目录。");
+        return 1;
+    }
+    const auto paths = acecode::desktop::macos_user_install_paths(
+        fs::path(home_bytes));
+    if (paths.home.empty()) {
+        show_error(@"The current user's home directory is invalid.\n\n当前用户的主目录无效。");
+        return 1;
+    }
+
+    NSURL* home_url = file_url(paths.home, YES);
+    NSURL* applications_url = file_url(paths.applications, YES);
+    NSURL* destination_url = file_url(paths.destination, YES);
+    if (!home_url || !applications_url || !destination_url) {
+        show_error(@"The user installation path could not be represented safely.\n\n无法安全表示用户安装路径。");
+        return 1;
+    }
+
+    BOOL applications_is_directory = NO;
+    const BOOL applications_exists =
+        [file_manager fileExistsAtPath:[applications_url path]
+                           isDirectory:&applications_is_directory];
+    if (applications_exists) {
+        bool applications_is_symlink = false;
+        error = nil;
+        if (!resource_flag(applications_url, NSURLIsSymbolicLinkKey,
+                           &applications_is_symlink, &error) ||
+            applications_is_symlink || applications_is_directory == NO) {
+            show_error(error_detail(
+                @"~/Applications must be a real directory inside your home folder.\n\n~/Applications 必须是主目录中的真实文件夹，不能是符号链接。",
+                error));
+            return 1;
+        }
+    } else {
+        error = nil;
+        if (![file_manager createDirectoryAtURL:applications_url
+                     withIntermediateDirectories:YES
+                                      attributes:nil
+                                           error:&error]) {
+            show_error(error_detail(
+                @"The installer could not create ~/Applications.\n\n安装器无法创建 ~/Applications。", error));
+            return 1;
+        }
+    }
+
+    NSURL* resolved_home = [home_url URLByResolvingSymlinksInPath];
+    NSURL* resolved_applications =
+        [applications_url URLByResolvingSymlinksInPath];
+    NSURL* resolved_destination =
+        [resolved_applications URLByAppendingPathComponent:@"ACECode.app"
+                                               isDirectory:YES];
+    if (!acecode::desktop::macos_user_install_destination_is_safe(
+            filesystem_path(resolved_home),
+            filesystem_path(resolved_applications),
+            filesystem_path(resolved_destination))) {
+        show_error(@"The resolved installation path is outside ~/Applications.\n\n解析后的安装路径不在 ~/Applications 中，安装已停止。");
+        return 1;
+    }
+    destination_url = resolved_destination;
+
+    BOOL destination_is_directory = NO;
+    const BOOL destination_exists =
+        [file_manager fileExistsAtPath:[destination_url path]
+                           isDirectory:&destination_is_directory];
+    if (destination_exists) {
+        bool destination_is_symlink = false;
+        error = nil;
+        if (!resource_flag(destination_url, NSURLIsSymbolicLinkKey,
+                           &destination_is_symlink, &error) ||
+            destination_is_symlink || destination_is_directory == NO) {
+            show_error(error_detail(
+                @"The existing ~/Applications/ACECode.app is not a replaceable application bundle.\n\n现有的 ~/Applications/ACECode.app 不是可安全替换的应用包。",
+                error));
+            return 1;
+        }
+    }
+
+    NSString* temporary_name = [NSString stringWithFormat:
+        @".ACECode-%@.installing.app", [[NSUUID UUID] UUIDString]];
+    NSURL* temporary_url =
+        [resolved_applications URLByAppendingPathComponent:temporary_name
+                                               isDirectory:YES];
+    error = nil;
+    if (![file_manager copyItemAtURL:source_url
+                               toURL:temporary_url
+                               error:&error]) {
+        show_error(error_detail(
+            @"The installer could not copy ACECode into ~/Applications.\n\n安装器无法将 ACECode 复制到 ~/Applications。", error));
+        return 1;
+    }
+
+    bool installed = false;
+    if (destination_exists) {
+        NSURL* resulting_url = nil;
+        error = nil;
+        installed = [file_manager replaceItemAtURL:destination_url
+                                     withItemAtURL:temporary_url
+                                    backupItemName:nil
+                                           options:NSFileManagerItemReplacementUsingNewMetadataOnly
+                                  resultingItemURL:&resulting_url
+                                             error:&error] == YES;
+    } else {
+        error = nil;
+        installed = [file_manager moveItemAtURL:temporary_url
+                                          toURL:destination_url
+                                          error:&error] == YES;
+    }
+
+    if (!installed) {
+        NSError* cleanup_error = nil;
+        [file_manager removeItemAtURL:temporary_url error:&cleanup_error];
+        show_error(error_detail(
+            @"The installer could not finish replacing ACECode.\n\n安装器无法完成 ACECode 的替换。", error));
+        return 1;
+    }
+
+    if (!bundle_identifier_matches(destination_url)) {
+        show_error(@"The installed application did not pass the final bundle check.\n\n安装后的应用未通过最终 Bundle 检查。");
+        return 1;
+    }
+
+    show_alert(NSAlertStyleInformational,
+               @"ACECode installed / ACECode 已安装",
+               @"Installed for the current user at ~/Applications/ACECode.app. No administrator access was requested.\n\n已为当前用户安装到 ~/Applications/ACECode.app，全程未请求管理员权限。ACECode 即将启动。");
+
+    if (![[NSWorkspace sharedWorkspace] openURL:destination_url]) {
+        show_error(@"ACECode was installed, but macOS could not open it automatically. Open ~/Applications/ACECode.app manually.\n\nACECode 已安装，但 macOS 无法自动启动。请手动打开 ~/Applications/ACECode.app。");
+        return 1;
+    }
+    return 0;
+}
+
 } // namespace
 
-int main() {
-    @autoreleasepool {
-        [NSApplication sharedApplication];
-        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-        [NSApp activateIgnoringOtherApps:YES];
+@interface ACECodeInstallerDelegate : NSObject <NSApplicationDelegate> {
+@private
+    NSURL* requested_source_url_;
+    BOOL installation_started_;
+    int exit_code_;
+}
 
-        NSFileManager* file_manager = [NSFileManager defaultManager];
-        NSURL* installer_url = [[NSBundle mainBundle] bundleURL];
-        NSURL* image_root = [installer_url URLByDeletingLastPathComponent];
-        NSURL* source_url = [image_root URLByAppendingPathComponent:@"ACECode.app"
-                                                        isDirectory:YES];
+- (int)exitCode;
+- (void)acceptOpenURLs:(NSArray<NSURL*>*)urls;
+- (void)beginInstallation;
 
-        BOOL source_is_directory = NO;
-        if (![file_manager fileExistsAtPath:[source_url path]
-                                isDirectory:&source_is_directory] ||
-            source_is_directory == NO) {
-            show_error(@"ACECode.app is missing beside the installer. Reopen the original DMG.\n\n安装器旁缺少 ACECode.app，请重新打开原始 DMG。");
-            return 1;
-        }
+@end
 
-        NSError* error = nil;
-        bool source_is_symlink = false;
-        if (!resource_flag(source_url, NSURLIsSymbolicLinkKey,
-                           &source_is_symlink, &error) || source_is_symlink) {
-            show_error(error_detail(
-                @"The ACECode payload is not a safe application bundle.\n\nACECode 安装文件不是安全的应用包。", error));
-            return 1;
-        }
-        if (!bundle_identifier_matches(source_url)) {
-            show_error(@"The ACECode payload has an unexpected bundle identifier.\n\nACECode 安装文件的 Bundle ID 不正确。");
-            return 1;
-        }
+@implementation ACECodeInstallerDelegate
 
-        NSArray<NSRunningApplication*>* running =
-            [NSRunningApplication runningApplicationsWithBundleIdentifier:
-                kAcecodeBundleIdentifier];
-        if ([running count] != 0) {
-            show_error(@"Quit ACECode, then open this installer again.\n\n请先退出 ACECode，然后重新打开安装器。");
-            return 1;
-        }
-
-        const char* home_bytes = [NSHomeDirectory() fileSystemRepresentation];
-        if (!home_bytes) {
-            show_error(@"The current user's home directory is unavailable.\n\n无法读取当前用户的主目录。");
-            return 1;
-        }
-        const auto paths = acecode::desktop::macos_user_install_paths(
-            fs::path(home_bytes));
-        if (paths.home.empty()) {
-            show_error(@"The current user's home directory is invalid.\n\n当前用户的主目录无效。");
-            return 1;
-        }
-
-        NSURL* home_url = file_url(paths.home, YES);
-        NSURL* applications_url = file_url(paths.applications, YES);
-        NSURL* destination_url = file_url(paths.destination, YES);
-        if (!home_url || !applications_url || !destination_url) {
-            show_error(@"The user installation path could not be represented safely.\n\n无法安全表示用户安装路径。");
-            return 1;
-        }
-
-        BOOL applications_is_directory = NO;
-        const BOOL applications_exists =
-            [file_manager fileExistsAtPath:[applications_url path]
-                               isDirectory:&applications_is_directory];
-        if (applications_exists) {
-            bool applications_is_symlink = false;
-            error = nil;
-            if (!resource_flag(applications_url, NSURLIsSymbolicLinkKey,
-                               &applications_is_symlink, &error) ||
-                applications_is_symlink || applications_is_directory == NO) {
-                show_error(error_detail(
-                    @"~/Applications must be a real directory inside your home folder.\n\n~/Applications 必须是主目录中的真实文件夹，不能是符号链接。",
-                    error));
-                return 1;
-            }
-        } else {
-            error = nil;
-            if (![file_manager createDirectoryAtURL:applications_url
-                         withIntermediateDirectories:YES
-                                          attributes:nil
-                                               error:&error]) {
-                show_error(error_detail(
-                    @"The installer could not create ~/Applications.\n\n安装器无法创建 ~/Applications。", error));
-                return 1;
-            }
-        }
-
-        NSURL* resolved_home = [home_url URLByResolvingSymlinksInPath];
-        NSURL* resolved_applications =
-            [applications_url URLByResolvingSymlinksInPath];
-        NSURL* resolved_destination =
-            [resolved_applications URLByAppendingPathComponent:@"ACECode.app"
-                                                   isDirectory:YES];
-        if (!acecode::desktop::macos_user_install_destination_is_safe(
-                filesystem_path(resolved_home),
-                filesystem_path(resolved_applications),
-                filesystem_path(resolved_destination))) {
-            show_error(@"The resolved installation path is outside ~/Applications.\n\n解析后的安装路径不在 ~/Applications 中，安装已停止。");
-            return 1;
-        }
-        destination_url = resolved_destination;
-
-        BOOL destination_is_directory = NO;
-        const BOOL destination_exists =
-            [file_manager fileExistsAtPath:[destination_url path]
-                               isDirectory:&destination_is_directory];
-        if (destination_exists) {
-            bool destination_is_symlink = false;
-            error = nil;
-            if (!resource_flag(destination_url, NSURLIsSymbolicLinkKey,
-                               &destination_is_symlink, &error) ||
-                destination_is_symlink || destination_is_directory == NO) {
-                show_error(error_detail(
-                    @"The existing ~/Applications/ACECode.app is not a replaceable application bundle.\n\n现有的 ~/Applications/ACECode.app 不是可安全替换的应用包。",
-                    error));
-                return 1;
-            }
-        }
-
-        NSString* temporary_name = [NSString stringWithFormat:
-            @".ACECode-%@.installing.app", [[NSUUID UUID] UUIDString]];
-        NSURL* temporary_url =
-            [resolved_applications URLByAppendingPathComponent:temporary_name
-                                                   isDirectory:YES];
-        error = nil;
-        if (![file_manager copyItemAtURL:source_url
-                                   toURL:temporary_url
-                                   error:&error]) {
-            show_error(error_detail(
-                @"The installer could not copy ACECode into ~/Applications.\n\n安装器无法将 ACECode 复制到 ~/Applications。", error));
-            return 1;
-        }
-
-        bool installed = false;
-        if (destination_exists) {
-            NSURL* resulting_url = nil;
-            error = nil;
-            installed = [file_manager replaceItemAtURL:destination_url
-                                         withItemAtURL:temporary_url
-                                        backupItemName:nil
-                                               options:NSFileManagerItemReplacementUsingNewMetadataOnly
-                                      resultingItemURL:&resulting_url
-                                                 error:&error] == YES;
-        } else {
-            error = nil;
-            installed = [file_manager moveItemAtURL:temporary_url
-                                              toURL:destination_url
-                                              error:&error] == YES;
-        }
-
-        if (!installed) {
-            NSError* cleanup_error = nil;
-            [file_manager removeItemAtURL:temporary_url error:&cleanup_error];
-            show_error(error_detail(
-                @"The installer could not finish replacing ACECode.\n\n安装器无法完成 ACECode 的替换。", error));
-            return 1;
-        }
-
-        if (!bundle_identifier_matches(destination_url)) {
-            show_error(@"The installed application did not pass the final bundle check.\n\n安装后的应用未通过最终 Bundle 检查。");
-            return 1;
-        }
-
-        show_alert(NSAlertStyleInformational,
-                   @"ACECode installed / ACECode 已安装",
-                   @"Installed for the current user at ~/Applications/ACECode.app. No administrator access was requested.\n\n已为当前用户安装到 ~/Applications/ACECode.app，全程未请求管理员权限。ACECode 即将启动。");
-
-        if (![[NSWorkspace sharedWorkspace] openURL:destination_url]) {
-            show_error(@"ACECode was installed, but macOS could not open it automatically. Open ~/Applications/ACECode.app manually.\n\nACECode 已安装，但 macOS 无法自动启动。请手动打开 ~/Applications/ACECode.app。");
-            return 1;
-        }
-        return 0;
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        requested_source_url_ = nil;
+        installation_started_ = NO;
+        exit_code_ = 1;
     }
+    return self;
+}
+
+- (void)dealloc {
+    [requested_source_url_ release];
+    [super dealloc];
+}
+
+- (int)exitCode {
+    return exit_code_;
+}
+
+- (void)applicationDidFinishLaunching:(NSNotification*)notification {
+    (void)notification;
+    [NSApp activateIgnoringOtherApps:YES];
+
+    // Finder normally delivers open-file events during launch. A short delay
+    // lets that event select the dragged payload before direct-open fallback.
+    [self performSelector:@selector(beginInstallation)
+               withObject:nil
+               afterDelay:0.25];
+}
+
+- (void)application:(NSApplication*)application
+            openURLs:(NSArray<NSURL*>*)urls {
+    (void)application;
+    [self acceptOpenURLs:urls];
+}
+
+- (void)application:(NSApplication*)application
+           openFiles:(NSArray<NSString*>*)filenames {
+    NSMutableArray<NSURL*>* urls =
+        [NSMutableArray arrayWithCapacity:[filenames count]];
+    for (NSString* filename in filenames) {
+        [urls addObject:[NSURL fileURLWithPath:filename isDirectory:YES]];
+    }
+    [self acceptOpenURLs:urls];
+    [application replyToOpenOrPrint:NSApplicationDelegateReplySuccess];
+}
+
+- (void)acceptOpenURLs:(NSArray<NSURL*>*)urls {
+    if (installation_started_ || requested_source_url_ || [urls count] == 0) {
+        return;
+    }
+
+    requested_source_url_ = [[urls objectAtIndex:0] retain];
+    [NSObject cancelPreviousPerformRequestsWithTarget:self
+                                             selector:@selector(beginInstallation)
+                                               object:nil];
+    [self performSelector:@selector(beginInstallation)
+               withObject:nil
+               afterDelay:0.05];
+}
+
+- (void)beginInstallation {
+    if (installation_started_) return;
+    installation_started_ = YES;
+
+    NSURL* source_url = expected_source_url();
+    if (requested_source_url_ &&
+        !dropped_source_is_expected(requested_source_url_, source_url)) {
+        show_error(@"Drag the ACECode.app from beside this installer. Other applications are not accepted.\n\n请拖入安装器旁边的 ACECode.app，不能安装其他应用。");
+        exit_code_ = 1;
+    } else {
+        exit_code_ = install_application(source_url);
+    }
+
+    [NSApp stop:self];
+}
+
+@end
+
+int main() {
+    int result = 1;
+    @autoreleasepool {
+        NSApplication* application = [NSApplication sharedApplication];
+        ACECodeInstallerDelegate* delegate =
+            [[ACECodeInstallerDelegate alloc] init];
+        [application setDelegate:delegate];
+        [application setActivationPolicy:NSApplicationActivationPolicyRegular];
+        [application run];
+        result = [delegate exitCode];
+        [application setDelegate:nil];
+        [delegate release];
+    }
+    return result;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,13 @@ if(UNIX)
             ${CMAKE_CURRENT_SOURCE_DIR}/scripts/macos_release_scripts_test.sh
     )
     set_tests_properties(macos_release_scripts_contract PROPERTIES LABELS "unit")
+
+    add_test(
+        NAME macos_dmg_layout_contract
+        COMMAND /bin/bash
+            ${CMAKE_CURRENT_SOURCE_DIR}/scripts/macos_dmg_layout_test.sh
+    )
+    set_tests_properties(macos_dmg_layout_contract PROPERTIES LABELS "unit")
 endif()
 
 file(GLOB_RECURSE ACECODE_TEST_SOURCES CONFIGURE_DEPENDS

--- a/tests/scripts/macos_dmg_layout_test.sh
+++ b/tests/scripts/macos_dmg_layout_test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+dmg_script="$repo_root/scripts/macos_create_dmg.sh"
+icon_script="$repo_root/scripts/macos_generate_icns.sh"
+desktop_cmake="$repo_root/cmake/acecode_desktop.cmake"
+installer_plist="$repo_root/cmake/macos/ACECodeUserInstallerInfo.plist.in"
+installer_source="$repo_root/src/macos_installer/main.mm"
+installer_icon="$repo_root/assets/macos/acecode-installer.svg"
+dmg_background="$repo_root/assets/macos/acecode-dmg-background.svg"
+
+temporary_root="$(mktemp -d "${TMPDIR:-/tmp}/acecode-dmg-layout-test.XXXXXX")"
+cleanup() {
+    if [[ -n "${temporary_root:-}" && -d "$temporary_root" ]]; then
+        rm -rf -- "$temporary_root"
+    fi
+}
+trap cleanup EXIT
+
+expect_status() {
+    local expected="$1"
+    local label="$2"
+    shift 2
+
+    local output="$temporary_root/output.txt"
+    local actual=0
+    "$@" >"$output" 2>&1 || actual=$?
+    if [[ "$actual" -ne "$expected" ]]; then
+        echo "$label: expected exit $expected, got $actual" >&2
+        sed -n '1,120p' "$output" >&2
+        exit 1
+    fi
+}
+
+bash -n "$dmg_script"
+bash -n "$icon_script"
+expect_status 0 "DMG help" bash "$dmg_script" --help
+expect_status 0 "ICNS help" bash "$icon_script" --help
+expect_status 2 "unknown DMG argument" bash "$dmg_script" --unknown
+expect_status 2 "unknown ICNS argument" bash "$icon_script" --unknown
+
+test -f "$installer_icon"
+test -f "$dmg_background"
+grep -Fq 'acecode-installer.icns' "$desktop_cmake"
+grep -Fq 'macos_generate_icns.sh' "$desktop_cmake"
+grep -Fq 'MACOSX_PACKAGE_LOCATION "Resources"' "$desktop_cmake"
+grep -Fq '<key>CFBundleDocumentTypes</key>' "$installer_plist"
+grep -Fq '<string>com.apple.application-bundle</string>' "$installer_plist"
+grep -Fq '<string>Alternate</string>' "$installer_plist"
+grep -Fq 'application:(NSApplication*)application' "$installer_source"
+grep -Fq 'openURLs:(NSArray<NSURL*>*)urls' "$installer_source"
+grep -Fq 'dropped_source_is_expected' "$installer_source"
+grep -Fq 'expected_source_url' "$installer_source"
+
+grep -Fq -- '-format UDRW' "$dmg_script"
+grep -Fq '/usr/bin/osascript' "$dmg_script"
+grep -Fq 'set background picture of iconOptions' "$dmg_script"
+grep -Fq 'set position of item "ACECode.app"' "$dmg_script"
+grep -Fq 'set position of item "Install ACECode.app"' "$dmg_script"
+grep -Fq '/usr/bin/hdiutil convert' "$dmg_script"
+grep -Fq -- '-format UDZO' "$dmg_script"
+grep -Fq '.VolumeIcon.icns' "$dmg_script"
+grep -Fq 'Refusing to package a system /Applications link.' "$dmg_script"
+
+if grep -Eq 'ln[[:space:]].*/Applications|ln[[:space:]]+-s[[:space:]]+/Applications' "$dmg_script"; then
+    echo "DMG helper must not create a system /Applications link" >&2
+    exit 1
+fi
+if grep -Eq 'Authorization(Create|CopyRights)|[[:space:]]sudo[[:space:]]' "$installer_source"; then
+    echo "Installer must not request administrator privileges" >&2
+    exit 1
+fi
+if grep -Fq '@"/Applications"' "$installer_source"; then
+    echo "Installer must not target system /Applications" >&2
+    exit 1
+fi
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    generated_icon="$temporary_root/acecode-installer.icns"
+    expect_status 0 "generate installer icon" \
+        bash "$icon_script" --source "$installer_icon" --output "$generated_icon"
+    test -s "$generated_icon"
+
+    /usr/bin/iconutil -c iconset -o "$temporary_root/icon.iconset" \
+        "$generated_icon"
+    test "$(find "$temporary_root/icon.iconset" -type f -name '*.png' | wc -l | tr -d ' ')" -eq 10
+
+    background_png="$temporary_root/ACECode-DMG.png"
+    /usr/bin/sips -s format png "$dmg_background" \
+        --out "$background_png" >/dev/null
+    test -s "$background_png"
+    /usr/bin/sips -g pixelWidth -g pixelHeight "$background_png" \
+        >"$temporary_root/background-size.txt"
+    grep -Fq 'pixelWidth: 720' "$temporary_root/background-size.txt"
+    grep -Fq 'pixelHeight: 520' "$temporary_root/background-size.txt"
+fi
+
+echo "macOS DMG layout contract checks passed"


### PR DESCRIPTION
## What changed

- style the macOS DMG as a branded left-to-right drag window
- keep the right-hand target as a signed current-user installer that writes only to `~/Applications/ACECode.app`
- accept Finder drops only for the sibling `ACECode.app`, while preserving double-click installation
- generate a distinct installer ICNS from an editable SVG and add a custom mounted-volume icon
- build a writable intermediate image, persist Finder layout metadata, then convert and verify read-only UDZO output
- add portable contract coverage for layout assets, drag metadata, and no-admin constraints

## Why

A conventional `/Applications` alias can require administrator access and violates ACECode's user-scoped installation contract. This keeps the familiar drag gesture while routing it through the existing safe installer.

## Verification

- `cmake --build build/macos-x64-desktop-release --target acecode-user-installer acecode-desktop --parallel 4`
- `bash tests/scripts/macos_dmg_layout_test.sh`
- `bash tests/scripts/macos_release_scripts_test.sh`
- `acecode_unit_tests --gtest_filter='UserInstallPolicy.*'` (6 passed)
- `npx --no-install openspec validate improve-macos-dmg-drag-install --strict`
- locally created, verified, mounted, and visually inspected the DMG
- confirmed `.DS_Store`, branded background, installer icon, and volume icon are present
- confirmed the image contains no `/Applications` link
