### PR TITLE
fix(tui): Terminal.app 不再误开 synchronized output

### DIFF
--- a/openspec/changes/add-synchronized-output/design.md
+++ b/openspec/changes/add-synchronized-output/design.md
@@ -36,7 +36,7 @@
 New pure helper `detect_synchronized_output_support_with(caps, env_lookup)` in `terminal_capability`:
 
 - **Blacklist (off, highest priority):** `ConEmuPID` set (ConEmu/Cmder), `caps.is_legacy_conhost` or `caps.is_classic_conhost`, `TERM` starting with `tmux` or `screen` (multiplexer version unknowable from env; force-able via config).
-- **Whitelist (on):** `WT_SESSION` set (Windows Terminal), `KITTY_WINDOW_ID` set or `TERM == "xterm-kitty"` (kitty), `TERM_PROGRAM` in `iTerm.app` / `WezTerm` / `ghostty` / `vscode` / `Apple_Terminal` / `WarpTerminal` / `contour` / `mintty`, `TERM` starting with `foot` or `ghostty`.
+- **Whitelist (on):** `WT_SESSION` set (Windows Terminal), `KITTY_WINDOW_ID` set or `TERM == "xterm-kitty"` (kitty), `TERM_PROGRAM` in `iTerm.app` / `WezTerm` / `ghostty` / `vscode` / `WarpTerminal` / `contour` / `mintty` (Apple_Terminal / macOS Terminal.app excluded: older versions don't implement DEC 2026; opt in via `tui.sync_output_mode="always"`), `TERM` starting with `foot` or `ghostty`.
 - **Unknown (off):** anything else, including POSIX terminals with no recognizable markers (e.g. Alacritty, plain `xterm-256color`).
 
 On non-Windows builds the Windows-only signals simply never fire and the POSIX rules apply. Terminals that ignore unknown DEC modes harmlessly would tolerate unconditional sending, but the conservative default protects the legacy-Windows moat and surprises no one; `sync_output_mode: "always"` overrides for adventurous users.

--- a/src/utils/terminal_capability.cpp
+++ b/src/utils/terminal_capability.cpp
@@ -115,7 +115,6 @@ bool term_program_whitelisted(const std::string& value) {
         "WezTerm",
         "ghostty",
         "vscode",          // VS Code 内嵌终端(xterm.js)
-        "Apple_Terminal",  // macOS Terminal.app
         "WarpTerminal",
         "contour",
         "mintty",

--- a/src/utils/terminal_capability.hpp
+++ b/src/utils/terminal_capability.hpp
@@ -63,7 +63,9 @@ inline bool should_use_conhost_compat_layout(const TerminalCapabilities& caps) {
 //   - TERM 以 "tmux" / "screen" 开头(复用器)      → false
 //   - WT_SESSION / KITTY_WINDOW_ID 存在            → true
 //   - TERM_PROGRAM ∈ {iTerm.app, WezTerm, ghostty, vscode,
-//                     Apple_Terminal, WarpTerminal, contour, mintty} → true
+//                     WarpTerminal, contour, mintty} → true
+//     (Apple_Terminal / macOS Terminal.app 不在此列:旧版本不支持 DEC 2026,
+//      保守关闭;需用时用 tui.sync_output_mode="always" 强制开启)
 //   - TERM == xterm-kitty 或以 foot/ghostty 开头    → true
 //   - 其它(未知终端,如 Alacritty / 裸 xterm-256color) → false
 //

--- a/tests/utils/terminal_capability_test.cpp
+++ b/tests/utils/terminal_capability_test.cpp
@@ -255,10 +255,10 @@ TEST(SynchronizedOutputSupport, KittyTermOn) {
 }
 
 // 场景:TERM_PROGRAM 白名单(iTerm.app / WezTerm / ghostty / vscode /
-// Apple_Terminal / WarpTerminal / contour / mintty)→ 开启
+// WarpTerminal / contour / mintty)→ 开启(Apple_Terminal 已移除,见下)
 TEST(SynchronizedOutputSupport, TermProgramWhitelistOn) {
     for (const char* name : {"iTerm.app", "WezTerm", "ghostty", "vscode",
-                             "Apple_Terminal", "WarpTerminal", "contour",
+                             "WarpTerminal", "contour",
                              "mintty"}) {
         TerminalCapabilities caps;
         EXPECT_TRUE(detect_synchronized_output_support_with(
@@ -266,6 +266,16 @@ TEST(SynchronizedOutputSupport, TermProgramWhitelistOn) {
                                        std::string(name), std::nullopt)))
             << "TERM_PROGRAM=" << name;
     }
+}
+
+// 场景:Apple Terminal.app 不支持 DEC mode 2026(尤其 macOS 12 及更早版本),
+// 从白名单移除,auto 模式默认关闭;需要时用 tui.sync_output_mode="always" 强制开启。
+TEST(SynchronizedOutputSupport, AppleTerminalOff) {
+    TerminalCapabilities caps;
+    EXPECT_FALSE(detect_synchronized_output_support_with(
+        caps, make_sync_env_lookup(std::nullopt, std::nullopt, std::nullopt,
+                                   std::string("Apple_Terminal"), std::nullopt)))
+        << "Apple_Terminal must NOT be whitelisted for DEC 2026";
 }
 
 // 场景:TERM 前缀白名单(foot / ghostty)→ 开启


### PR DESCRIPTION
## 问题

`detect_synchronized_output_support()` 的 `TERM_PROGRAM` 白名单里包含 `Apple_Terminal`（macOS 自带 Terminal.app），但 Terminal.app 并未实现 **DEC mode 2026**（synchronized output）。

后果：`auto` 模式下用 Terminal.app 时会被误判为“支持”，从而每帧发送 `CSI ?2026h` / `CSI ?2026l`，终端直接忽略该序列 —— 特性静默无效，且用户无从感知。

> 注：网络资料存在分歧（terminfo.dev 标为支持，ansicode 特性矩阵标为不支持），推测是新版 macOS（26 Tahoe）重写过的 Terminal.app 才支持。考虑到 ACECode 需要覆盖 macOS 12 等旧版本，且探测函数本身采取“未知即关闭”的保守策略，此处按不支持处理。

## 改动

- `src/utils/terminal_capability.cpp`：白名单移除 `Apple_Terminal`（精确匹配，移除后不会命中任何开启路径）
- `src/utils/terminal_capability.hpp`：同步注释，说明原因与 `always` 兜底
- `tests/utils/terminal_capability_test.cpp`：白名单循环移除该条目，新增 `AppleTerminalOff` 用例断言 `TERM_PROGRAM=Apple_Terminal` 时返回 `false`
- `openspec/changes/add-synchronized-output/design.md`：同步探测规则描述

## 影响面

仅 `auto` 模式下 Terminal.app 的行为从“开启（且无效）”变为“关闭”。其余终端不受影响。

确需该行为的终端仍可通过配置强制开启：

```json
{ "tui": { "sync_output_mode": "always" } }
```

## 验证

改动仅涉及 `terminal_capability.cpp` / 测试文件两个编译单元，单独编译并链接 gtest 运行：

```
[==========] 26 tests from 2 test suites ran.
[  PASSED  ] 26 tests.
```

含新增的 `AppleTerminalOff`，以及原有 11 个同步输出探测用例（iTerm/WezTerm/ghostty/kitty/foot/vscode/mintty 开启，ConEmu/legacy conhost/tmux/screen/未知 关闭）与终端能力探测用例全部通过。

（全量 `acecode_unit_tests` 未重跑：改动头文件会被大面积 include，本机双核 i5 全量重编预计一小时以上；ninja 增量状态保留，需要时可续跑确认。）