### PR TITLE
docs: 竞品调研整合报告（11 产品对比 + 代码核实 + 改进规划）

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -25,6 +25,10 @@
 - [plan/backlog.md](plan/backlog.md)：非阻塞后续事项。
 - [string-utilities-refactor.md](string-utilities-refactor.md)：字符串工具统一重构方案（**未启动**，含现状盘点与护栏设计）。
 
+## 调研
+
+- [竞品调研报告_完整版_2026-08.md](竞品调研报告_完整版_2026-08.md)：11 产品竞品全景对比（Pi / Claude Code / Codex / Qoder / Trae / Cowork 等），关键论断已逐条对照源码核实，含 Phase 0–3 改进规划。
+
 ## 复盘
 
 - [postmortem-file-link-preview.md](postmortem-file-link-preview.md)：AI 生成的文件链接点不开 —— 渲染、编码、路径、数据传递四层缺陷的定位过程与回归防线。

--- a/docs/竞品调研报告_完整版_2026-08.md
+++ b/docs/竞品调研报告_完整版_2026-08.md
@@ -1,0 +1,254 @@
+# acecode 竞品调研报告（完整整合版）
+
+> 生成日期：2026-08-31
+> 代码核实基准：acecode 仓库 HEAD `2006b416`（master `d380673d` + 1 个 TUI 修复提交）
+>
+> 输入来源（7 份，全部整合入本报告）：
+> 1. `pi-analysis/competitive-matrix.md` —— 8 工具 A–R 能力矩阵
+> 2. `pi-analysis/pi-user-stories.md` —— Pi 用户故事拆解（约 90 条）与 acecode TUI 对比
+> 3. `research/竞品用户故事与acecode_desktop对比分析.md` —— OpenHands/Cline/Goose/Kilo 四开源竞品源码拆解（20 组 A–T 用户故事）
+> 4. `research/竞品分析增量_新增6竞品.md` —— WorkBuddy/Qoder/Trae/Claude Code/Claude Cowork/Codex 增量分析（U–Z 新分组）
+> 5. `research/竞品用户故事全景_含10竞品_acecode_desktop对比.md` —— 10 竞品全景 A–Z（约 61 项对比）
+> 6. `research/产品调研报告_整合版_代码核实.md` —— 08-28 首轮代码核实 + 08-31 二次复核
+> 7. `research/改进规划_acecode.md` —— 08-31 修订版改进规划（Phase 0–3）
+>
+> 竞品源码核实仓库：`research/{cline,goose,kilocode,openhands}`（4 个完整源码仓库，共约 1.8 万文件）。
+> 对比取值约定：`优` = 优于对手；`弱` = 弱于对手；`平` = 各有千秋；`=` = 相平。
+
+---
+
+## 0. 一页结论
+
+1. **acecode 的底座比外部报告描述的更完整**。内置 MCP（`/mcp` + 运行时管理器）、`/plan` 计划模式 + 权限分级、子代理（spawn_subagent + `/tasks` + Web Swarm）、TodoWrite、opencode 式自定义命令（`$ARGUMENTS`）、Copilot/Grok OAuth、`acecode upgrade` 自更新均已落地。外部报告约 **1/3 的"缺口"实际已存在**。
+2. **真实缺口集中在 TUI 细节交互与"元能力"**：`/thinking` 级别切换、Ctrl+G 外部编辑器、`/hotkeys` 键位总览与会话元命令（`/clone` `/share` `/copy`）、离线开关、OS 级沙箱、Web 检查点时间线 UI、成本金额估算。除沙箱外均无架构风险，属"低成本高收益"。
+3. **战略层缺口**（对标 Qoder Quest / Trae SOLO / Claude Cowork）：Computer Use、云端异步长任务、企业治理（SSO/审计）、代码库知识显性化（RepoWiki 类）、移动/远程入口——这些是"下一代战场"，不是当前用户流失原因。
+4. **唯一且扎实的稳赢点是"本地优先/隐私"**：Trae（字节遥测争议）与 Qoder（阿里数据驻留顾虑）均为云端产品；acecode 数据不出本机，应作为核心卖点，而非继续与巨头硬刚 agent 功能广度。
+5. **桌面外壳已非护城河**：10 竞品口径下，首版 11 项桌面"优"中 6 项被 Qoder/Trae/Cowork 追平为"平"；但代码核实又收回 2 项（Plan/Act 切换、子代理编排实际已有），桌面层真实状态好于外部报告的悲观口径。
+
+---
+
+## 1. 产品定位速览（11 产品）
+
+| 产品 | 形态 | 核心卖点 | 与 acecode 关系 |
+|---|---|---|---|
+| Pi Coding Agent | TS/Node CLI + 扩展运行时 | 极简核心 + 可塑形生态（MCP/计划/权限等刻意不做） | 单对单对标基准 |
+| acecode | C++17 TUI + daemon + Web + 原生 Desktop | 全栈终端 Agent：内置 MCP/计划/权限/后台/子代理 + 本地优先 | 本体 |
+| Claude Code | TS/Node CLI | 最强生态 + 企业可控 | 终端正面竞品 |
+| Codex CLI | Rust + TS | OS 级沙箱（默认禁网只读）+ Cloud 异步 | 安全标杆 |
+| Grok Build | Rust | local-first + Claude 配置兼容 | 全功能型 |
+| Trae CLI / Qoder CLI | Python / TS | 轻量研究子集 / 云端 Agentic OS | 生态型 |
+| Kimi Code CLI | TS + Rust | 开源平替 + 多模态（视频输入） | 性价比型 |
+| OpenHands / Cline / Goose / Kilo Code | Web / VS Code 扩展 / 桌面 / 多端扩展 | 控制平面 / 人在环路 / 本地优先 / 多 Agent 市场 | agent 能力层竞品 |
+| Qoder（IDE）/ Trae（IDE）/ Claude Cowork | 桌面 IDE / 应用 | Quest 自主交付 / SOLO / Computer Use + 企业治理 | 桌面叙事竞品 |
+| WorkBuddy | 多端 AI 工作台 | Agent + Skills + 连接器生态（平台层，不参与打分） | 平台宿主 |
+
+**关键认知**：Pi 的产品哲学是"刻意不做"——MCP、子代理、计划模式、权限弹窗、待办清单、后台 bash 全部外包给扩展生态；acecode 反其道全部内置，这是对 Pi 的结构性优势（R 组）。而桌面竞品从"少"变"多且强"，agent 标杆被抬到"端到端自主 + 云端长任务"，acecode 应避开正面战场。
+
+---
+
+## 2. 代码核实结果（对照 HEAD `2006b416`，2026-08-31）
+
+### 2.1 已确认存在的能力（12 项，含证据）
+
+| # | 能力 | 证据（文件 + 行号） |
+|---|---|---|
+| 1 | 内置 MCP：`/mcp` 命令 + 运行时管理 + 启动协调 | `src/tool/mcp_manager.cpp`、`mcp_startup_coordination.cpp`、`builtin_commands.cpp:1990` |
+| 2 | 计划模式 `/plan` + 权限模式 `/mode` | `builtin_commands.cpp:1964,1968`、`src/tool/plan_mode_tool.cpp` |
+| 3 | 子代理：spawn_subagent 工具 + `/tasks` 后台任务 + Web Swarm | `src/tool/spawn_subagent_tool.cpp`、`builtin_commands.cpp:2022`、`web/src/components/SwarmModeIcon.jsx` |
+| 4 | TodoWrite 工具 | `src/tool/todo_write_tool.cpp` |
+| 5 | opencode 式 markdown 自定义命令（`$ARGUMENTS` 插值，注册为斜杠命令） | `src/commands/opencode_command.cpp`、`opencode_command_registry.cpp` |
+| 6 | OAuth：GitHub Copilot Device Flow + Grok Coding Plan（xAI） | `src/provider/auth/github_auth.{hpp,cpp}`、`xai_auth.{hpp,cpp}`、`web/routes/routes_models.cpp` |
+| 7 | 自更新 `acecode upgrade` / `update` | `src/upgrade/`（apply / manifest / package / version）、`src/tui/cli_dispatch.cpp` |
+| 8 | 复制助手消息（鼠标选区 OSC52 / 系统剪贴板） | `src/main.cpp` clipboard_copy_status_message 路径、`src/tui/clipboard_helpers.cpp` |
+| 9 | AGENTS.md 默认加载（PR #25，2026-08-30 修复） | `src/config/config.hpp` filenames = AGENT.md / AGENTS.md / CLAUDE.md，带 `read_claude_md` 逐名开关 |
+| 10 | Web token/上下文用量环 | `web/src/components/TokenBudgetRing.jsx`、`web/src/lib/tokenBudget.js`，`ChatView.jsx` 已接入 |
+| 11 | Web/Desktop composer 权限模式选择器（default / accept-edits / plan） | `web/src/components/ComposerSessionControls.jsx`、`web/src/lib/permissionMode.js` |
+| 12 | 外部 URL 安全唤起（白名单校验 + 剪贴板细节） | `src/desktop/` external_url 处理链路 |
+
+实测注册的斜杠命令全清单（`builtin_commands.cpp:1949-2027`）：`help clear new mode config tokens goal plan compact resume rewind checkpoint fork mcp skills feedback tasks title page-step theme exit`，另经独立注册函数挂载 `model models init history proxy websearch lsp remote_control desktop memory archive`。
+
+### 2.2 外部报告论断被代码推翻 / 修正的（8 项）
+
+| # | 原报告论断 | 核实结果 |
+|---|---|---|
+| 1 | "无用户级提示模板机制" | 不成立：opencode 式自定义命令已实现（见 2.1 #5） |
+| 2 | "无订阅 OAuth 登录，主要靠 Key" | 大部分不成立：Copilot / Grok OAuth 已落地；缺 Anthropic / OpenAI 订阅 OAuth |
+| 3 | "子代理弱 / 缺原生编排" | 被低估：spawn_subagent + `/tasks` + Web Swarm 模式（composer 开关 + expert 芯片） |
+| 4 | "待办清单缺失" | 已有 TodoWrite 工具 |
+| 5 | "桌面壳未暴露 Plan/Act 切换" | 不成立：Web/Desktop composer 底部已有权限模式选择器 + 模型选择器 + expert 选择 |
+| 6 | "MCP 支持需核实" | 已内置且完整（见 2.1 #1） |
+| 7 | "更新机制未明确" | 已有 `acecode upgrade` 完整链路 |
+| 8 | "无复制最后消息" | 部分成立：选区复制已有；专用"复制最后助手消息"键确实无 |
+
+### 2.3 核实为真实缺口且当前仍未修复的（10 项）
+
+以下逐名检索 `src/commands/`、`src/`、`web/src/`，当前 HEAD 全部确认缺失：
+
+| # | 缺口 | 现状证据 | 对标 |
+|---|---|---|---|
+| 1 | 无 `/thinking`（别名 `/effort`）命令 | `saved_models.cpp:76,614,646` 仅有 effort 数据层；models.dev 目录已解析 `reasoning_efforts`；无命令注册 | CC / CX / Qoder / Kimi |
+| 2 | 无 Ctrl+G 外部编辑器 | `$EDITOR` 仅用于 `/memory edit`（`memory_command.cpp`） | Pi / CC / CX / Qoder / Kimi |
+| 3 | 无 `/hotkeys`、键位不可配置 | 全库无 keybind 机制（grep 无命中）；`settings_state.cpp` 的 FooterAction 枚举不算命令 | Pi（keybindings.json）/ CC / Qoder |
+| 4 | 会话元命令缺失：`/clone` `/share` `/copy` `/session` `/export` `/changelog` | 不在命令清单（2.1） | CC / Goose / Kimi |
+| 5 | 无 OS 级沙箱 | seatbelt / landlock / bubblewrap 全库无命中 | Codex（默认禁网只读）标杆 |
+| 6 | 无离线开关 | `ACECODE_OFFLINE` 等价物无命中 | Pi `--offline` |
+| 7 | 无 `/reload` 统一热重载 | 不在命令清单；`/skills` 子命令层面可重注册，上下文文件 / 主题 / 配置无统一重载 | Pi `/reload` |
+| 8 | 无项目信任门禁与 `/trust` 命令 | hooks 仅 hook 级 trust 状态，无启动信任提示 | Pi `/trust`、CC workspace trust |
+| 9 | Web 检查点时间线 UI 缺失 | `web/src/lib/api.js:570` restoreSessionCheckpoint 已定义但全库无调用者（后端 API 已有） | Cline / Kilo / Qoder |
+| 10 | 无成本金额估算 | `tokenBudget.js` 无 cost / price 折算（token 用量环已有） | Cline / Kilo / Qoder |
+
+### 2.4 核实时间线
+
+- **08-28 首轮**：逐条对照源码，推翻 8 项、确认 11 项缺口（详见来源 6）。
+- **08-30**：PR #25 合入，AGENTS.md 默认加载修复（缺口 #1 闭环）。
+- **08-31 二次复核**（HEAD `d380673d`）：命令面比外部报告更全；Web 用量环确认部分存在（缺金额）。
+- **08-31 本轮终核**（HEAD `2006b416`）：2.1 / 2.3 全部条目重新验证，仅多 1 个与本调研无关的 TUI 修复提交，结论与二次复核一致。
+
+### 2.5 OpenSpec 在途状态（66 个变更目录）
+
+本轮认领的缺口变更（早前按仓库 OpenSpec 规范创建，可直接推进实现）：
+
+```
+openspec/changes/add-thinking-effort-command/      （缺口 #1）
+openspec/changes/add-external-editor-composer/     （缺口 #2）
+openspec/changes/add-session-meta-commands/        （缺口 #4）
+openspec/changes/add-offline-and-update-switches/  （缺口 #6）
+```
+
+注意：`add-hotkeys-overview`（缺口 #3）创建中断，目录未落成，需补建。另有他人变更 `stabilize-tui-thinking-render`（thinking 渲染稳定性，非 effort 命令，不冲突）。其余 60+ 变更均不覆盖 2.3 所列缺口。
+
+### 2.6 竞品源码抽查（4 仓库，逐条验证外部报告论断）
+
+| 论断 | 结论 | 证据 |
+|---|---|---|
+| Cline 有 checkpoint 快照与回滚 | 确认 | `docs/core-workflows/checkpoints.mdx`、`apps/cli/src/tui/checkpoint-picker-items.ts`（CLI 也有）、`apps/vscode/proto/cline/checkpoints.proto` |
+| Cline 有分级自动批准 | 确认 | `apps/vscode/src/shared/AutoApprovalSettings.ts` |
+| Goose 有 Recipes 参数化工作流 | 确认 | `workflow_recipes/`、`.github/recipes/`、`scripts/test_subrecipes.sh` |
+| Goose 有跨会话记忆 | 确认 | 项目级 `.goose/memory` 目录约定 |
+| OpenHands 有 ACP 多代理后端 | 确认 | `docs/ACP_AGENTS.md`、`tests/e2e/live-acp/`、`__tests__/utils/acp-*.test.ts` |
+| Kilo Code 有 marketplace | 确认（早前源码拆解口径；本轮文件名抽查未直接命中，按拆解报告保留） | 早前子代理拆解 |
+
+外部报告对竞品的描述整体可信，无重大失实。
+
+---
+
+## 3. 综合能力评估（TUI 与 Desktop 双视角合并）
+
+### 3.1 TUI / CLI 视角（对标 Pi + 7 个 CLI 竞品）
+
+- **覆盖度：中高**。核心交互（@ 引用、! shell、折叠、消息队列 steering、`/compact`、`/rewind`、`/fork`、skills、themes、headless、Web RPC）与 Pi 基本相平。
+- **明确强项**：内置 MCP / 计划 / 权限 / 后台 / 子代理 / TodoWrite——Pi "刻意不做"的六项全部内置且可用，这是结构性优势。
+- **真实短板**：§2.3 #1–#8，全部属于低成本可补的交互细节与元能力。
+
+### 3.2 Desktop 视角（对标 10 竞品，约 61 项对比）
+
+对比结论分布：
+
+| 结论 | 数量 | 说明 |
+|---|---|---|
+| 优 | 约 2 项 | 外部 URL 安全唤起；隐私 / 数据本地驻留（因 Trae/Qoder 云遥测痛点逆势升级） |
+| 弱 | 约 30 项 | 集中在 agent 层产品能力（检查点 UI、用量面板、技能市场、免 Key、配方、OAuth、PR 评审）及全部新分组 U–Z |
+| 平 | 约 6 项 | 原生窗口 / 托盘 / 拾取器 / 本地化 / DPI / 桌面客户端（首版"优"全部被桌面 IDE 竞品追平） |
+| = | 约 20 项 | 基础对话、文件读写、终端执行、历史搜索、提供商、@ 引用、记忆压缩、规则、密钥、通知等 |
+
+代码核实修正后的真实桌面缺口（好于外部报告口径）：检查点时间线 UI（API 已有）、成本金额、原生 diff 审阅窗口（现 diff 在 Web 层渲染）、技能/MCP 发现市场（有管理面板、无市场）、Computer Use、云端异步、企业治理、移动远程。
+
+### 3.3 关键判断
+
+1. **桌面外壳已不是壁垒**：Qoder / Trae / Claude Cowork 均为完整桌面 IDE / 应用；代理浏览器宿主从"独有"降为"被 Computer Use 压制的利基"。
+2. **新战场在"自主 + 云端 + 企业 + OS 级操作"**：Quest / SOLO / Cloud Agents、Computer Use、SSO 审计、RepoWiki 是六款新增竞品共同发力方向，acecode 近乎空白。
+3. **代码核实挽回了两项误判**：Plan/Act 切换与子代理编排实际已具备（Web 层），外部报告的"桌面全面落后"口径过悲观。
+4. **唯一稳赢点是本地优先 / 隐私**，应作为核心卖点。
+
+---
+
+## 4. 战略结论
+
+1. **不与巨头硬刚"云端自主 IDE"**（Quest / SOLO / Cloud Agents 是烧钱战场，无胜算）。
+2. **主打定位："数据不出本机的全功能专业编码 Agent"** —— 本地优先 + 内置重型能力（MCP / 计划 / 权限 / 子代理）+ 三端一体（TUI / Web / Desktop 共享 daemon）+ 借 WorkBuddy 连接器 / 技能生态补市场短板。对外口径同步更新 README / 官网，把 §2.1 优势清单显性化。
+3. **先补齐成本最低、收益最高的短板**（§2.3 #1–#4、#6 + 检查点 UI + 成本金额），一两个迭代内将 TUI / 桌面体验拉到竞品同等水位。
+4. **中期差异化二选一聚焦**（不建议全铺）：
+   - **路线 A「安全深度」**：OS 级沙箱（对标 Codex 默认禁网只读）+ 项目信任门禁 + 审计日志，面向对企业可控有要求的本地用户；
+   - **路线 B「桌面自主」**：代理浏览器宿主升级为"人驱动 + agent 接管"融合范式，向受限 Computer Use（先浏览器后关键 App）演进。
+5. **远期观察项**（保持跟踪，不先投入）：RepoWiki 类知识显性化、Spec 驱动、语音输入、多智能体 PR 评审。
+
+---
+
+## 5. 改进规划
+
+### Phase 0：已闭环（无需排期）
+
+| 项 | 状态 | 证据 |
+|---|---|---|
+| 默认加载 AGENTS.md | 已完成 | PR #25（5a8a2d54）；`config.hpp` 三文件名列表 |
+| Web token / 上下文用量环 | 已完成 | `TokenBudgetRing.jsx` + `tokenBudget.js` + `ChatView.jsx` |
+
+剩余动作：README 补一句 AGENTS.md 支持说明；用量环补金额（并入 Phase 2）。
+
+### Phase 1：体验水位补齐（1 个迭代，1–2 周）
+
+低风险、无架构改动的增量，4 项已建 OpenSpec 变更：
+
+| # | 改进项 | OpenSpec 变更 | 具体做法 |
+|---|---|---|---|
+| 1 | `/thinking` 思维级别切换 | `add-thinking-effort-command` | 数据层已就绪（`ModelReasoningOptions`，取值以 models.dev 目录 `reasoning_efforts` 为准）。无参显示当前值与可选值；有参校验后写入会话级 provider 设置；模型不支持时列出合法取值 |
+| 2 | Ctrl+G 外部编辑器 | `add-external-editor-composer` | composer 内 Ctrl+G：输入缓冲写临时文件，调 `$VISUAL` / `$EDITOR`（回落 nano / Notepad）后读回；复用 `memory_command.cpp` 的编辑器取值逻辑 |
+| 3 | 会话元操作 | `add-session-meta-commands` | `/clone`（复制当前会话）；`/copy`（复制最后一条助手消息，复用 clipboard_helpers）；`/session`（会话文件路径 / ID / 消息数 / token） |
+| 4 | 离线与更新开关 | `add-offline-and-update-switches` | `ACECODE_OFFLINE=1` 跳过启动期网络动作（模型目录刷新、升级检查、连接器探测）；`/config` 增 update.check_on_start 与 telemetry.enabled 开关 |
+| 5 | `/hotkeys` 键位总览 | 待补建（早前创建中断） | 先做只读 `/hotkeys` 面板枚举 TUI 键位表；键位自定义放 Phase 2（需键位映射层） |
+
+### Phase 2：桌面叙事 + 信任安全（1–2 个迭代）
+
+| # | 改进项 | 具体做法 | 优先级 |
+|---|---|---|---|
+| 6 | Web/Desktop 检查点时间线 UI | 消息气泡菜单加"回滚到此消息"，三选项（仅文件 / 仅会话 / 文件+会话）+ diff 预览；接上 `api.js:570` 的 restoreSessionCheckpoint（现无调用者） | Must |
+| 7 | 项目信任门禁 + `/trust` | 启动检测到项目级 hooks / 本地设置时询问信任；非交互模式单次覆盖 | Must（安全路线基础） |
+| 8 | 成本估算面板 | 在 TokenBudgetRing 上按模型单价折算金额（prompt / completion / cache-read），常驻侧栏 + TUI 状态行；`/tokens` 升级累计视图 | Should |
+| 9 | `/reload` 统一热重载 | 重载上下文文件、主题、技能、opencode 命令（注册/注销机制已有） | Should |
+| 10 | AGENTS.override.md + SYSTEM.md | override 文件替代同目录其他指令文件；`.acecode/SYSTEM.md` 支持替换系统提示 | Should |
+| 11 | 键位可配置 | keybindings.json（全局 + 项目两层），先覆盖核心 15 键；依赖 #5 的键位表 | Should |
+| 12 | 会话导出与分享 | `/export`（HTML / JSONL）+ `/share`（Gist 或静态链接，显式确认后上传） | Should |
+| 13 | 私有技能/连接器市场 MVP | 现有管理面板加"发现"页：远程 manifest + 一键安装；先支持 git / 本地路径来源 | Should |
+| 14 | OS 级沙箱（路线 A 押注） | macOS Seatbelt（只读文件系统 + 默认禁网）；Linux Landlock + seccomp；Windows restricted token 最佳努力；权限模式与沙箱联动 | Should（差异化） |
+
+### Phase 3：差异化纵深（季度级，二选一聚焦）
+
+- **路线 A「安全深度」**：审计日志（工具调用 / 文件写入 / 网络请求结构化落盘，可导出 JSONL / OTel）→ 权限分级 UI（读 / 写 / 命令 / MCP 四类白名单）→ 企业部署文档化（离线安装、签名校验、数据边界声明）。
+- **路线 B「桌面自主」**：代理浏览器宿主加"让 agent 接管此页"开关 → 受限 Computer Use（浏览器内点击 / 填表 / 导航，经权限门禁）→ 自主交付模式（plan → 检查点时间线 → 自动验证 → 交付报告）。
+- **两条路线共做**：Anthropic / OpenAI 订阅 OAuth（补齐 auth 层仅 Copilot / Grok 的空位）；`/changelog`（配合 `acecode upgrade`）。
+
+### 不做清单（明确 Won't，避免资源稀释）
+
+- 云端托管长任务 / 云 IDE（与 Codex Cloud / Qoder Cloud 正面战，烧钱无胜算）；
+- 完整 Computer Use 通用控屏（Cowork 已产品级，先做浏览器级即可）；
+- npm 式扩展运行时 / TS 扩展生态（Pi 的路线，与 C++ 架构冲突；hooks + MCP + skills 已覆盖大部分场景）;
+- 企业 SSO / SIEM（无企业客户信号前仅留接口设计）；
+- 语音输入、RepoWiki、Spec 驱动（保持跟踪，竞品验证后再评估）。
+
+### 依赖关系
+
+```
+Phase 1（#1–#5 互相独立，可并行）
+    #5 /hotkeys ──→ #11 键位可配置（前置）
+#7 信任门禁 ──→ #14 OS 沙箱 ──→ 路线A 审计
+#6 检查点UI ──→ 路线B 自主交付（时间线是前置）
+#13 市场MVP ──→ 私有分发（路线A 企业项）
+```
+
+### 度量与验收
+
+- Phase 1 结束：与 Pi 的用户故事对比中"弱于对手"从约 30 条降至约 15 条；
+- Phase 2 结束：10 竞品全景表中桌面"弱"项（检查点 / 成本 / 市场 / 信任）清零；
+- 持续：每特性带单测（命令 / 解析层进 `acecode_testable`），行为回归用 headless JSONL 快照对比。
+
+---
+
+## 6. 附录：核实方法说明
+
+- 命令清单：`src/commands/builtin_commands.cpp:1949-2027`（register_builtin_commands）+ 各 `register_*_command` 独立注册；
+- 指令文件：`src/config/config.hpp`（ProjectInstructionsConfig）+ `src/project_instructions/instructions_loader.cpp`；
+- OAuth：`src/provider/auth/{github_auth,xai_auth}.*`、`web/routes/routes_models.cpp`；
+- 子代理 / 待办 / 计划：`src/tool/{spawn_subagent_tool,todo_write_tool,plan_mode_tool}.cpp`、`src/tui/subagent_host.hpp`；
+- Web UI：`web/src/components/{ComposerSessionControls,SwarmModeIcon,TokenBudgetRing}.jsx`、`web/src/lib/{api.js,tokenBudget.js,permissionMode.js}`；
+- 沙箱 / 离线 / 键位：全源码关键词检索（sandbox / seatbelt / landlock、offline、keybind）均无产品级实现；
+- 竞品抽查：`research/cline`（checkpoint / AutoApprovalSettings）、`research/goose`（workflow_recipes / .goose/memory）、`research/openhands`（ACP 文档与 e2e 测试）、`research/kilocode`（早前源码拆解）。


### PR DESCRIPTION
## 变更内容

把 `research/` 与 `pi-analysis/` 两个目录下共 7 份竞品调研材料，整合为一份完整报告放入 `docs/竞品调研报告_完整版_2026-08.md`，并在 `docs/INDEX.md` 新增「调研」章节登记入口。

**所有关键论断均已对照当前 HEAD（`2006b416`）源码逐条核实**，不写代码、不涉及行为变更。

## 核实结论

**已确认具备的能力（12 项，推翻外部报告中 8 项失实论断）**

- 内置 MCP（`/mcp` + `mcp_manager.cpp` + 启动协调）
- `/plan` 计划模式 + 权限模式 `/mode`
- 子代理 `spawn_subagent_tool` + `/tasks` + Web Swarm
- TodoWrite、opencode 式自定义命令（`$ARGUMENTS`）
- Copilot / Grok OAuth、`acecode upgrade` 自更新
- AGENTS.md 默认加载（PR #25 已修复）、Web 用量环（`TokenBudgetRing`）

**确认仍存在的真实缺口（10 项）**

`/thinking` 级别切换 · Ctrl+G 外部编辑器 · `/hotkeys` 键位总览 · 会话元命令（`/clone` `/share` `/copy`）· OS 级沙箱 · 离线开关 · `/reload` · 项目信任门禁 · Web 检查点时间线 UI（`restoreSessionCheckpoint` 已定义但无调用者）· 成本金额估算

**竞品源码抽查**：Cline checkpoint 与 `AutoApprovalSettings`、Goose `workflow_recipes`、OpenHands ACP 均确认存在，外部报告对竞品描述可信。

## 战略结论

- 唯一扎实稳赢点是「本地优先 / 数据不出本机」（对标 Trae 遥测争议、Qoder 数据驻留顾虑），建议作为核心卖点。
- 桌面外壳已被 Qoder / Trae / Cowork 追平，不再构成壁垒；不建议在云端自主 IDE 方向硬刚。
- 中期差异化二选一：路线 A「安全深度」（OS 沙箱 + 信任门禁 + 审计）或路线 B「桌面自主」（代理浏览器宿主 + 受限 Computer Use）。

## 验证方式

纯文档变更，无构建影响。核实方法见报告 §6 附录（含全部检索式与文件路径）。

## 待办提示

Phase 1 中 `add-hotkeys-overview` 的 OpenSpec 变更目录此前创建中断，需补建；其余 4 个变更（`add-thinking-effort-command`、`add-external-editor-composer`、`add-session-meta-commands`、`add-offline-and-update-switches`）已就绪可直接推进实现。