### PR TITLE
Release v0.9.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if(CMAKE_HOST_WIN32 AND DEFINED CMAKE_TOOLCHAIN_FILE AND CMAKE_TOOLCHAIN_FILE MA
     set(VCPKG_TARGET_TRIPLET "x64-windows-static" CACHE STRING "Vcpkg target triplet" FORCE)
 endif()
 
-project(acecode VERSION 0.9.10 LANGUAGES C CXX)
+project(acecode VERSION 0.9.11 LANGUAGES C CXX)
 
 option(ACECODE_TUI_INPUT_TRACE "Enable verbose TUI input event trace logging." OFF)
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name":  "acecode",
-    "version-semver":  "0.9.10",
+    "version-semver":  "0.9.11",
     "dependencies":  [
                          "cpr",
                          "crow",


### PR DESCRIPTION
## Summary
- set the CMake and vcpkg release version to 0.9.11
- prepare the verified two-day integration on master for the stable release tag

## Verification
- PR #40 Linux build, models.dev validation, and CTest passed
- local Windows build, Web tests/build, focused regression tests, and full CTest inventory passed