### PR TITLE
[codex] fix: chat home workspace switch delay on new task

### DIFF
--- a/web/src/components/ChatView.jsx
+++ b/web/src/components/ChatView.jsx
@@ -2456,6 +2456,15 @@ export function ChatView({ sessionRef, sessionId, homeLogoEffectEnabled = true, 
     if (sid) setCreateProjectOpen(false);
   }, [sid]);
 
+  // ref 携带 homeWorkspaceExplicit 时,工作区归属是导航意图的一部分:
+  // 同步落到 homeWorkspaceHash,不等 /api/workspaces 返回。否则点击
+  // 「新建任务」后,聊天区的工作区显示、提交目标、命令工作区、输入历史
+  // 都要等整个列表请求回来才切到无工作区(实测 3-4 秒)。
+  useEffect(() => {
+    if (sid || !ref?.homeWorkspaceExplicit) return;
+    setHomeWorkspaceHash(ref?.workspaceHash || '');
+  }, [ref?.homeWorkspaceExplicit, ref?.workspaceHash, sid]);
+
   useEffect(() => {
     if (sid) return undefined;
     let cancelled = false;
@@ -2522,8 +2531,13 @@ export function ChatView({ sessionRef, sessionId, homeLogoEffectEnabled = true, 
   useEffect(() => {
     const cwd = sid
       ? (ref?.cwd || health?.cwd || '')
-      : (selectedHomeWorkspace?.cwd || ref?.cwd || health?.cwd || '');
-    if (!cwd) return;
+      : (selectedHomeWorkspace?.cwd || ref?.cwd || '');
+    if (!cwd) {
+      // 无工作空间的新任务没有 per-cwd 历史;显式清掉上一次工作区残留,
+      // 避免上下键翻出上一个项目的输入历史。
+      setHistory([]);
+      return;
+    }
     api.getHistory(cwd, 200)
       .then((r) => setHistory(Array.isArray(r) ? r : []))
       .catch(() => {});


### PR DESCRIPTION
## 背景

用户反馈：在项目上新建任务后，点击工具栏顶部的「新建任务」，聊天区的已选工作空间要 3-4 秒才能切换到「无工作空间」。

## 根因

ChatView 里聊天区空态的工作区相关控件（工作区选择显示、提交目标、斜杠命令工作区、输入历史）都派生自 `homeWorkspaceHash` / `selectedHomeWorkspace`，而这个状态只在 `GET /api/workspaces` 异步返回后才更新。点击「新建任务」时 ref 已同步切到无工作空间，但 `homeWorkspaceHash` 仍停留在上一个项目，直到列表请求回来（该请求在刚创建完会话的 daemon 上可能排队数秒）才切过去。

## 修改

- ChatView.jsx：当 ref 携带 `homeWorkspaceExplicit` 时，用 `ref.workspaceHash` 同步设置 `homeWorkspaceHash`，不再等待工作区列表；异步加载后 `resolveHomeWorkspaceHash` 的 explicit 分支解析出相同值，不会闪回。
- 连带：home 模式输入历史只认选中工作区的 cwd，切到无工作空间时显式清空残留历史，避免上下键翻出上一个项目的输入。

## 影响

点击「新建任务」后，聊天区工作区显示、提交目标、命令工作区、专家列表、输入历史立即切换到无工作空间，消除 3-4 秒延迟。

## 验证

- 全部 2069 个测试通过（0 失败）。